### PR TITLE
Added metadata support to the post_publish.rb script

### DIFF
--- a/oc_modules/README.md
+++ b/oc_modules/README.md
@@ -1,0 +1,10 @@
+Post Processing Modules
+========================
+
+This folder contains custom Ruby modules that are required by the post processing scripts to run properly.
+
+To install them, place this folder with all its files into the same directory as the post processing script you are using.
+The path should then look something like this (the * start stands for either `archive` or `publish`, depending on
+which script you are using):
+
+    /usr/local/bigbluebutton/core/scripts/post_*/oc_modules

--- a/oc_modules/oc_acl.rb
+++ b/oc_modules/oc_acl.rb
@@ -1,0 +1,318 @@
+require_relative 'oc_util'
+require_relative 'oc_dublincore'
+
+require 'nokogiri'        #XML-Parser
+require 'json'
+
+module OcAcl
+
+  def self.private_module_function(name)   #:nodoc:
+    module_function name
+    private_class_method name
+  end
+
+  #
+  # Returns the metadata tags defined for user access list
+  #
+  # return: hash
+  #
+  def getAclMetadataDefinition()
+    return {:readRoles => "opencast-acl-read-roles",
+            :writeRoles => "opencast-acl-write-roles",
+            :userIds => "opencast-acl-user-id"}
+  end
+  private_module_function :getAclMetadataDefinition
+
+  #
+  # Returns the metadata tags defined for series access list
+  #
+  # return: hash
+  #
+  def getSeriesAclMetadataDefinition()
+    return {:readRoles => "opencast-series-acl-read-roles",
+            :writeRoles => "opencast-series-acl-write-roles",
+            :userIds => "opencast-series-acl-user-id"}
+  end
+  private_module_function :getSeriesAclMetadataDefinition
+
+  #
+  # Parses acl-relevant information from the metadata
+  #
+  # metadata: hash (string => string)
+  # defaultReadRoles: string with comma seperated values, roles that should ALWAYS have read access
+  # defaultWriteRoles: string with comma seperated values, roles that should ALWAYS have write access
+  #
+  # return array of hash (symbol => string, symbol => string)
+  #
+  def parseAclMetadata(metadata, acl_metadata_definition, defaultReadRoles = "", defaultWriteRoles = "")
+    # Cast keys to lowercase
+    metadata = OcUtil::keysLowerCase(metadata)
+
+    acl_data = []
+
+    # Read from global, configured-by-user variable
+    defaultReadRoles.to_s.split(",").each do |role|
+      acl_data.push( { :user => role, :permission => "read" } )
+    end
+    defaultWriteRoles.to_s.split(",").each do |role|
+      acl_data.push( { :user => role, :permission => "write" } )
+    end
+
+    # Read from Metadata
+    metadata[acl_metadata_definition[:readRoles]].to_s.split(",").each do |role|
+      acl_data.push( { :user => role, :permission => "read" } )
+    end
+    metadata[acl_metadata_definition[:writeRoles]].to_s.split(",").each do |role|
+      acl_data.push( { :user => role, :permission => "write" } )
+    end
+
+    metadata[acl_metadata_definition[:userIds]].to_s.split(",").each do |userId|
+      acl_data.push( { :user => "ROLE_USER_#{userId}", :permission => "read" } )
+      acl_data.push( { :user => "ROLE_USER_#{userId}", :permission => "write" } )
+    end
+
+    return acl_data
+  end
+  private_module_function :parseAclMetadata
+
+  def parseEpisodeAclMetadata(metadata, defaultReadRoles = "", defaultWriteRoles = "")
+    return parseAclMetadata(metadata, getAclMetadataDefinition(), defaultReadRoles, defaultWriteRoles)
+  end
+  module_function :parseEpisodeAclMetadata
+
+
+  def parseSeriesAclMetadata(metadata, defaultReadRoles = "", defaultWriteRoles = "")
+    return parseAclMetadata(metadata, getSeriesAclMetadataDefinition(), defaultReadRoles, defaultWriteRoles)
+  end
+  module_function :parseSeriesAclMetadata
+
+  #
+  # Creates a xml using the given role information
+  #
+  # roles: array of hash (symbol => string, symbol => string), containing user role and permission
+  #
+  # returns: string, the xml
+  #
+  def createAcl(roles)
+    header = Nokogiri::XML('<?xml version = "1.0" encoding = "UTF-8" standalone ="yes"?>')
+    builder = Nokogiri::XML::Builder.with(header) do |xml|
+      xml.Policy('PolicyId' => 'mediapackage-1',
+      'RuleCombiningAlgId' => 'urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:permit-overrides',
+      'Version' => '2.0',
+      'xmlns' => 'urn:oasis:names:tc:xacml:2.0:policy:schema:os') {
+        roles.each do |role|
+          xml.Rule('RuleId' => "#{role[:user]}_#{role[:permission]}_Permit", 'Effect' => 'Permit') {
+            xml.Target {
+              xml.Actions {
+                xml.Action {
+                  xml.ActionMatch('MatchId' => 'urn:oasis:names:tc:xacml:1.0:function:string-equal') {
+                    xml.AttributeValue('DataType' => 'http://www.w3.org/2001/XMLSchema#string') { xml.text(role[:permission]) }
+                    xml.ActionAttributeDesignator('AttributeId' => 'urn:oasis:names:tc:xacml:1.0:action:action-id',
+                    'DataType' => 'http://www.w3.org/2001/XMLSchema#string')
+                  }
+                }
+              }
+            }
+            xml.Condition{
+              xml.Apply('FunctionId' => 'urn:oasis:names:tc:xacml:1.0:function:string-is-in') {
+                xml.AttributeValue('DataType' => 'http://www.w3.org/2001/XMLSchema#string') { xml.text(role[:user]) }
+                xml.SubjectAttributeDesignator('AttributeId' => 'urn:oasis:names:tc:xacml:2.0:subject:role',
+                'DataType' => 'http://www.w3.org/2001/XMLSchema#string')
+              }
+            }
+          }
+        end
+      }
+    end
+
+    return builder.to_xml
+  end
+  module_function :createAcl
+
+  #
+  # Creates a xml using the given role information
+  #
+  # roles: array of hash (symbol => string, symbol => string), containing user role and permission
+  #
+  # returns: string, the xml
+  #
+  def createSeriesAcl(roles)
+    header = Nokogiri::XML('<?xml version = "1.0" encoding = "UTF-8" standalone ="yes"?>')
+    builder = Nokogiri::XML::Builder.with(header) do |xml|
+      xml.acl('xmlns' => 'http://org.opencastproject.security') {
+        roles.each do |role|
+          xml.ace {
+            xml.action { xml.text(role[:permission]) }
+            xml.allow { xml.text('true') }
+            xml.role { xml.text(role[:user]) }
+          }
+        end
+      }
+    end
+
+    return builder.to_xml
+  end
+  private_module_function :createSeriesAcl
+
+  #
+  # Extends a series ACL with given roles, if those roles are not already part of the ACL
+  #
+  # xml: A parsable xml string
+  # roles: array of hash (symbol => string, symbol => string), containing user role and permission
+  #
+  # returns:
+  #
+  def updateSeriesAcl(xml, roles)
+
+    doc = Nokogiri::XML(xml)
+    newNodeSet = Nokogiri::XML::NodeSet.new(doc)
+
+    roles.each do |role|
+      newNode = OcUtil::nokogiriNodeCreator(doc, "ace", "")
+      newNode << OcUtil::nokogiriNodeCreator(doc, "action", role[:permission])
+      newNode <<  OcUtil::nokogiriNodeCreator(doc, "allow", 'true')
+      newNode <<  OcUtil::nokogiriNodeCreator(doc, "role", role[:user])
+
+      # Avoid adding duplicate nodes
+      nodeAlreadyExists = false
+      doc.xpath("//x:ace", "x" => "http://org.opencastproject.security").each do |oldNode|
+        if OcUtil::sameNodes?(oldNode, newNode)
+          nodeAlreadyExists = true
+          break
+        end
+      end
+
+      if (!nodeAlreadyExists)
+        newNodeSet << newNode
+      end
+    end
+
+    doc.root << newNodeSet
+
+    return doc.to_xml
+  end
+  private_module_function :updateSeriesAcl
+
+  #
+  # Will create a new series with the given Id, if such a series does not yet exist
+  # Else will try to update the ACL of the series
+  #
+  # createSeriesId: string, the UID for the new series
+  #
+  def createSeries(meeting_metadata, oc_server, oc_user, oc_password, defaultSeriesRolesWithReadPerm="", defaultSeriesRolesWithWritePerm="")
+    if !oc_server || !oc_user || !oc_password
+      BigBlueButton.logger.warn(" OC_ACL: Cannot create or update series: No credentials given.")
+      return nil
+    end
+
+    # Cast keys to lowercase
+    meeting_metadata = OcUtil::keysLowerCase(meeting_metadata)
+
+    createSeriesId = meeting_metadata["opencast-dc-ispartof"]
+    if (createSeriesId.to_s.empty?)
+      BigBlueButton.logger.warn(" OC_ACL: Cannot create or update series: Metadata does not contain a seriesId.")
+      return
+    end
+
+    BigBlueButton.logger.info( "OC_ACL: Attempting to create a new series...")
+
+    # Acquire information about all series
+    seriesFromOc = []
+    begin
+      seriesFromOc = RestClient::Request.new(
+        :method => :get,
+        :url => oc_server + '/series/allSeriesIdTitle.json',
+        :user => oc_user,
+        :password => oc_password,
+        :payload => {}
+      ).execute
+    rescue RestClient::Exception => e
+      "LOG WARN Could not acquire information about series, Exception #{e}"
+      return
+    end
+
+    # Check if a series with the given identifier does already exist
+    seriesExists = false
+    begin
+      seriesFromOc = JSON.parse(seriesFromOc)
+      seriesFromOc["series"].each do |serie|
+        BigBlueButton.logger.info( "OC_ACL: Found series: " + serie["identifier"].to_s)
+        if (serie["identifier"].to_s === createSeriesId.to_s)
+          seriesExists = true
+          BigBlueButton.logger.info( "OC_ACL: Series already exists")
+          break
+        end
+      end
+    rescue JSON::ParserError  => e
+      BigBlueButton.logger.warn(" OC_ACL: Could not parse series JSON, Exception #{e}")
+    end
+
+    # Create Series
+    if (!seriesExists)
+      BigBlueButton.logger.info( "OC_ACL: Create a new series with ID " + createSeriesId)
+      # Create Series-DC
+      seriesDcData = OcDublincore::parseSeriesDcMetadata(meeting_metadata)
+      seriesDublincore = OcDublincore::createDublincore(seriesDcData)
+      # Create Series-ACL
+      seriesAcl = createSeriesAcl(parseSeriesAclMetadata(meeting_metadata, defaultSeriesRolesWithReadPerm,
+                  defaultSeriesRolesWithWritePerm))
+      BigBlueButton.logger.info( "OC_ACL: seriesAcl: " + seriesAcl.to_s)
+
+      begin
+        response = RestClient::Request.new(
+          :method => :post,
+          :url => oc_server + '/series/',
+          :user => oc_user,
+          :password => oc_password,
+          :payload => { :series => seriesDublincore,
+                        :acl => seriesAcl,
+                        :override => false}
+        ).execute
+      rescue RestClient::Exception => e
+        "LOG WARN Something went wrong during series creation, Exception #{e}"
+        return
+      end
+
+    # Update Series ACL
+    else
+      BigBlueButton.logger.info( "OC_ACL: Updating series ACL...")
+      # seriesAcl = requestIngestAPI(:get, '/series/' + createSeriesId + '/acl.xml', DEFAULT_REQUEST_TIMEOUT, {})
+      seriesAcl = []
+      begin
+        seriesAcl = RestClient::Request.new(
+          :method => :get,
+          :url => oc_server + '/series/' + createSeriesId + '/acl.xml',
+          :user => oc_user,
+          :password => oc_password,
+          :payload => { }
+        ).execute
+      rescue RestClient::Exception => e
+        "LOG WARN OC_ACL: Something went wrong during series update, Exception #{e}"
+        return
+      end
+      roles = parseSeriesAclMetadata(meeting_metadata, defaultSeriesRolesWithReadPerm, defaultSeriesRolesWithWritePerm)
+
+      if (roles.length > 0)
+        updatedSeriesAcl = updateSeriesAcl(seriesAcl, roles)
+        begin
+          response = RestClient::Request.new(
+            :method => :post,
+            :url => oc_server + '/series/' + createSeriesId + '/accesscontrol',
+            :user => oc_user,
+            :password => oc_password,
+            :payload => { :acl => updatedSeriesAcl,
+                          :override => false }
+          ).execute
+        rescue RestClient::Exception => e
+          "LOG WARN OC_ACL: Something went wrong during series update, Exception #{e}"
+          return
+        end
+        BigBlueButton.logger.info( "OC_ACL: Updated series ACL")
+      else
+        BigBlueButton.logger.info( "OC_ACL: Nothing to update ACL with")
+      end
+    end
+  end
+  module_function :createSeries
+
+end

--- a/oc_modules/oc_dublincore.rb
+++ b/oc_modules/oc_dublincore.rb
@@ -1,0 +1,282 @@
+require_relative 'oc_util'
+
+require 'rest-client'     #Easier HTTP Requests
+require 'date' #The method 'to_datetime'
+
+module OcDublincore
+
+  def self.private_module_function(name)   #:nodoc:
+    module_function name
+    private_class_method name
+  end
+
+  #
+  # Creates a definition for metadata, containing symbol, identifier and fallback
+  #
+  # metadata: hash (string => string)
+  # meetingStartTime: time, as a fallback for the "created" metadata-field
+  #
+  # return: array of hashes
+  #
+  def getDcMetadataDefinition(metadata, useSharedNotesForDescriptionFallback, passIdentifierAsDcSource,
+                              meetingStartTime, meetingEndTime)
+    dc_metadata_definition = []
+    dc_metadata_definition.push( { :symbol   => :title,
+                                  :fullName => "opencast-dc-title",
+                                  :fallback => metadata['meetingname']})
+    dc_metadata_definition.push( { :symbol   => :identifier,
+                                  :fullName => "opencast-dc-identifier",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :creator,
+                                  :fullName => "opencast-dc-creator",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :isPartOf,
+                                  :fullName => "opencast-dc-ispartof",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :contributor,
+                                  :fullName => "opencast-dc-contributor",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :subject,
+                                  :fullName => "opencast-dc-subject",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :language,
+                                  :fullName => "opencast-dc-language",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :description,
+                                  :fullName => "opencast-dc-description",
+                                  :fallback => useSharedNotesForDescriptionFallback ?
+                                               sharedNotesToString(SHARED_NOTES_PATH) : nil})
+    dc_metadata_definition.push( { :symbol   => :spatial,
+                                  :fullName => "opencast-dc-spatial",
+                                  :fallback => "BigBlueButton"})
+    dc_metadata_definition.push( { :symbol   => :created,
+                                  :fullName => "opencast-dc-created",
+                                  :fallback => meetingStartTime})
+    dc_metadata_definition.push( { :symbol   => :rightsHolder,
+                                  :fullName => "opencast-dc-rightsholder",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :license,
+                                  :fullName => "opencast-dc-license",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :publisher,
+                                  :fullName => "opencast-dc-publisher",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :temporal,
+                                  :fullName => "opencast-dc-temporal",
+                                  :fallback => (meetingStartTime && meetingEndTime) ?
+                                                "start=#{Time.at(meetingStartTime / 1000).to_datetime};
+                                                end=#{Time.at(meetingEndTime / 1000).to_datetime};
+                                                scheme=W3C-DTF"
+                                                : nil})
+    dc_metadata_definition.push( { :symbol   => :source,
+                                  :fullName => "opencast-dc-source",
+                                  :fallback => passIdentifierAsDcSource ?
+                                               metadata["opencast-dc-identifier"] : nil })
+    return dc_metadata_definition
+  end
+  module_function :getDcMetadataDefinition
+
+  #
+  # Parses dublincore-relevant information from the metadata
+  # or inserts a fallback value if applicable
+  #
+  # Will try to guarantee valid data.
+  # To that end, OC API requests may be required.
+  #
+  # metadata: hash (string => string)
+  # useSharedNotesForDescriptionFallback: bool
+  # passIdentifierAsDcSource: bool
+  # **args:
+  # startTime: optional, unixtime. Fallback for the start time of the recording
+  # endTime: optional, unixtime. Fallback for the end time of the recording
+  # server: optional, string. OC server address
+  # user: optional, string. OC user name
+  # password: optional, string. OC user password
+  #
+  # return hash (symbol => object)
+  #
+  def parseDcMetadata(metadata, getSeriesMetadata=false, useSharedNotesForDescriptionFallback=false, passIdentifierAsDcSource=false, **args)
+    # Cast keys to lowercase
+    metadata = OcUtil::keysLowerCase(metadata)
+
+    # Get an array of hashes for with key names and fallback values
+    dc_metadata_definition = getDcMetadataDefinition(metadata, useSharedNotesForDescriptionFallback,
+      passIdentifierAsDcSource, args[:startTime], args[:stopTime])
+
+    # Get values for the given keys, or use fallback values of the key does not exist
+    dc_data = {}
+    dc_metadata_definition.each do |definition|
+      dc_data[definition[:symbol]] = OcUtil::parseMetadataFieldOrFallback(metadata, definition[:fullName], definition[:fallback])
+    end
+
+    # A non-empty title is required for a successful ingest
+    if dc_data[:title].to_s.empty?
+      dc_data[:title] = "Default Title"
+    end
+
+    # Avoid using invalid or existing ids (to avoid ingest errors and accidental overwrites)
+    dc_data[:identifier] = checkEventIdentifier(dc_data[:identifier], args[:server], args[:user], args[:password])
+
+    return dc_data
+  end
+  module_function :parseDcMetadata
+
+  #
+  # Checks if the given identifier is valid to be used for an Opencast event
+  #
+  # identifier: string, to be used as the UID for an Opencast event
+  #
+  # Returns the identifier if it is valid, nil if not
+  #
+  def checkEventIdentifier(identifier, oc_server, oc_user, oc_password)
+    # Check for nil & empty
+    if identifier.to_s.empty? || !oc_server || !oc_user || !oc_password
+      return nil
+    end
+
+    # Check for UUID conformity
+    uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    if !(identifier.to_s.downcase =~ uuid_regex)
+      BigBlueButton.logger.info( "OC_DUBLINCORE: The given identifier <#{identifier}> is not a valid UUID. Will be using generated UUID instead.")
+      return nil
+    end
+
+    # Check for existence in Opencast
+    existsInOpencast = true
+    begin
+      response = RestClient::Request.new(
+        :method => :get,
+        :url => oc_server + "/api/events/" + identifier,
+        :user => oc_user,
+        :password => oc_password,
+      ).execute
+    rescue RestClient::Exception => e
+      existsInOpencast = false
+    end
+    if existsInOpencast
+      BigBlueButton.logger.info( "OC_DUBLINCORE: The given identifier <#{identifier}> already exists within Opencast. Will be using generated UUID instead.")
+      return nil
+    end
+
+    return identifier
+  end
+  private_module_function :checkEventIdentifier
+
+  #
+  # Creates a dublincore xml
+  #
+  # dc:data: array of hashes (symbol => string), contains the values for the different dublincore terms
+  #
+  # return: the complete xml, string
+  #
+  def createDublincore(dc_data)
+    # A non-empty title is required for a successful ingest
+    if dc_data[:title].to_s.empty?
+      dc_data[:title] = "Default Title"
+    end
+
+    # Basic structure
+    dublincore = []
+    dublincore.push("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+    dublincore.push("<dublincore xmlns=\"http://www.opencastproject.org/xsd/1.0/dublincore/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">")
+    dublincore.push("</dublincore>")
+    dublincore = dublincore.join("\n")
+
+    # Create nokogiri doc
+    doc = Nokogiri::XML(dublincore)
+    node_set = Nokogiri::XML::NodeSet.new(doc)
+
+    # Create nokogiri nodes
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:title', dc_data[:title])
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:identifier', dc_data[:identifier])      if dc_data[:identifier]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:creator', dc_data[:creator])            if dc_data[:creator]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:isPartOf', dc_data[:isPartOf])          if dc_data[:isPartOf]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:contributor', dc_data[:contributor])    if dc_data[:contributor]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:subject', dc_data[:subject])            if dc_data[:subject]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:language', dc_data[:language])          if dc_data[:language]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:description', dc_data[:description])    if dc_data[:description]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:spatial', dc_data[:spatial])            if dc_data[:spatial]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:created', dc_data[:created])            if dc_data[:created]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:rightsHolder', dc_data[:rightsHolder])  if dc_data[:rightsHolder]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:license', dc_data[:license])            if dc_data[:license]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:publisher', dc_data[:publisher])        if dc_data[:publisher]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:temporal', dc_data[:temporal])          if dc_data[:temporal]
+    node_set << OcUtil::nokogiriNodeCreator(doc, 'dcterms:source', dc_data[:source])              if dc_data[:source]
+
+    # Add nodes
+    doc.root.add_child(node_set)
+
+    # Finalize
+    return doc.to_xml
+  end
+  module_function :createDublincore
+
+  #
+  # Creates a definition for metadata, containing symbol, identifier and fallback
+  #
+  # metadata: hash (string => string)
+  #
+  # return: array of hashes
+  #
+  def getSeriesDcMetadataDefinition(metadata)
+    dc_metadata_definition = []
+    dc_metadata_definition.push( { :symbol   => :title,
+                                  :fullName => "opencast-series-dc-title",
+                                  :fallback => metadata['meetingname']})
+    dc_metadata_definition.push( { :symbol   => :identifier,
+                                  :fullName => "opencast-dc-isPartOf",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :creator,
+                                  :fullName => "opencast-series-dc-creator",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :contributor,
+                                  :fullName => "opencast-series-dc-contributor",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :subject,
+                                  :fullName => "opencast-series-dc-subject",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :language,
+                                  :fullName => "opencast-series-dc-language",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :description,
+                                  :fullName => "opencast-series-dc-description",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :rightsHolder,
+                                  :fullName => "opencast-series-dc-rightsholder",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :license,
+                                  :fullName => "opencast-series-dc-license",
+                                  :fallback => nil})
+    dc_metadata_definition.push( { :symbol   => :publisher,
+                                  :fullName => "opencast-series-dc-publisher",
+                                  :fallback => nil})
+    return dc_metadata_definition
+  end
+  private_module_function :getSeriesDcMetadataDefinition
+
+  #
+  # Parses dublincore-relevant information from the metadata
+  # or inserts a fallback value if applicable
+  #
+  # Will try to guarantee valid data.
+  # To that end, OC API requests may be required.
+  #
+  # metadata: hash (string => string)
+  #
+  # return hash (symbol => object)
+  #
+  def parseSeriesDcMetadata(metadata)
+    # Get an array of hashes for with key names and fallback values
+    dc_metadata_definition = getSeriesDcMetadataDefinition(metadata)
+
+    # Get values for the given keys, or use fallback values of the key does not exist
+    dc_data = {}
+    dc_metadata_definition.each do |definition|
+      dc_data[definition[:symbol]] = OcUtil::parseMetadataFieldOrFallback(metadata, definition[:fullName], definition[:fallback])
+    end
+
+    return dc_data
+  end
+  module_function :parseSeriesDcMetadata
+
+end

--- a/oc_modules/oc_util.rb
+++ b/oc_modules/oc_util.rb
@@ -1,0 +1,117 @@
+require 'nokogiri'        #XML-Parser
+
+module OcUtil
+
+  def self.private_module_function(name)   #:nodoc:
+    module_function name
+    private_class_method name
+  end
+
+  #
+  # Helper function: Convert metadata keys to lowercase
+  # Transform_Keys is only available from ruby 2.5 onward :(
+  #metadata = metadata.transform_keys(&:downcase)
+  #
+  private def keysLowerCase(oldHash)
+    newHash = {}
+    oldHash.each do |key, value|
+      newHash["#{key.downcase}"] = oldHash[key] #.delete("#{key}")
+    end
+    return newHash
+  end
+  module_function :keysLowerCase
+
+  #
+  # Helper function that determines if the metadata in question exists
+  #
+  # metadata: hash (string => string)
+  # metadata_name: string, the key we hope exists in metadata
+  # fallback: object, what to return if it doesn't (or is empty)
+  #
+  # return: the value corresponding to metadata_name or fallback
+  #
+  def parseMetadataFieldOrFallback(metadata, metadata_name, fallback)
+    return !(metadata[metadata_name.downcase].to_s.empty?) ?
+      metadata[metadata_name.downcase] : fallback
+  end
+  module_function :parseMetadataFieldOrFallback
+
+  #
+  # Helper function for creating xml nodes
+  #
+  def nokogiriNodeCreator(doc, name, content, attributes = nil)
+    new_node = Nokogiri::XML::Node.new(name, doc)
+    new_node.content = content
+    unless attributes.nil?
+      attributes.each do |attribute|
+        new_node.set_attribute(attribute[:name], attribute[:value])
+      end
+    end
+    return new_node
+  end
+  module_function :nokogiriNodeCreator
+
+  #
+  # Recursively check if 2 Nokogiri nodes are the same
+  # Does not check for attributes
+  #
+  # node1: The first Nokogiri node
+  # node2: The second Nokogori node
+  #
+  # returns: boolean, true if the nodes are equal
+  #
+  def sameNodes?(node1, node2, truthArray=[])
+    if node1.nil? || node2.nil?
+      return false
+    end
+    if node1.name != node2.name
+      return false
+    end
+    if node1.text != node2.text
+            return false
+    end
+    node1Attrs = node1.attributes
+    node2Attrs = node2.attributes
+    node1Kids = node1.children
+    node2Kids = node2.children
+    node1Kids.zip(node2Kids).each do |pair|
+      truthArray << sameNodes?(pair[0],pair[1])
+    end
+    # if every value in the array is true, then the nodes are equal
+    return truthArray.all?
+  end
+  module_function :sameNodes?
+
+  #
+  # Sends a web request to Opencast, using the credentials defined at the top
+  #
+  # method: Http method, symbol (e.g. :get, :post)
+  # url: ingest method, string (e.g. '/ingest/addPartialTrack')
+  # timeout: seconds until request returns with a timeout, numeric
+  # payload: information necessary for the request, hash
+  #
+  # return: The web request response
+  #
+  def requestIngestAPI(server, user, password, method, url, timeout, payload, additionalErrorMessage="")
+    begin
+      response = RestClient::Request.new(
+        :method => method,
+        :url => server + url,
+        :user => user,
+        :password => password,
+        :timeout => timeout,
+        :payload => payload
+      ).execute
+    rescue RestClient::Exception => e
+      BigBlueButton.logger.error(" A problem occured for request: #{url}")
+      BigBlueButton.logger.info( e)
+      BigBlueButton.logger.info( e.http_body)
+      BigBlueButton.logger.info( additionalErrorMessage)
+      exit 1
+    end
+
+    return response
+  end
+  module_function :requestIngestAPI
+
+end

--- a/post-archive/README.md
+++ b/post-archive/README.md
@@ -31,6 +31,10 @@ Setup BBB
 - Place the script `post_archive.rb` in 
     
     `/usr/local/bigbluebutton/core/scripts/post_archive/`
+    
+    Place the folder `oc_modules` from the top-level of this repository in the same location. 
+    
+    `/usr/local/bigbluebutton/core/scripts/post_archive/oc_modules`
 - In the script `post_archive.rb`, change the global variables in the "opencast configuration":
 	- In `post_archive.rb`, change the variable `$oc_server` to point to your Opencast installation
 	- Also change `$oc_user` and `oc_password` to a user of your opencast installation that is allowed to ingest (e.g. 

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -6,6 +6,10 @@ require 'mini_magick'     #Image Conversion
 require 'streamio-ffmpeg' #Accessing video information
 require File.expand_path('../../../lib/recordandplayback', __FILE__)  # BBB Utilities
 
+require_relative 'oc_modules/oc_dublincore'
+require_relative 'oc_modules/oc_acl'
+require_relative 'oc_modules/oc_util'
+
 ### opencast configuration begin
 
 # Server URL
@@ -58,9 +62,9 @@ $doNotConvertVideosAgain = true
 # EXPERIMENTIAL! This may cause the process spawned from this script to run a lot longer than anticipated.
 # Suggested default: false
 $monitorOpencastAfterIngest = false
-# Time between each state check
+# Time between each state check in seconds
 $secondsBetweenChecks = 300
-# Fail-safe. Time until the process is terminated no matter what.
+# Fail-safe. Time in seconds until the process is terminated no matter what.
 $secondsUntilGiveUpMax = 86400
 
 ### opencast configuration end
@@ -314,68 +318,6 @@ def collectFileInformation(tracks, flavor, startTimes, real_start_time)
 end
 
 #
-# Helper function for creating xml nodes
-#
-def nokogiri_node_creator (doc, name, content, attributes = nil)
-  new_node = Nokogiri::XML::Node.new(name, doc)
-  new_node.content = content
-  unless attributes.nil?
-    attributes.each do |attribute|
-      new_node.set_attribute(attribute[:name], attribute[:value])
-    end
-  end
-  return new_node
-end
-
-#
-# Creates a dublincore xml
-#
-# dc:data: array of hashes (symbol => string), contains the values for the different dublincore terms
-#
-# return: the complete xml, string
-#
-def createDublincore(dc_data)
-  # A non-empty title is required for a successful ingest
-  if dc_data[:title].to_s.empty?
-    dc_data[:title] = "Default Title"
-  end
-
-  # Basic structure
-  dublincore = []
-  dublincore.push("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
-  dublincore.push("<dublincore xmlns=\"http://www.opencastproject.org/xsd/1.0/dublincore/\" xmlns:dcterms=\"http://purl.org/dc/terms/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">")
-  dublincore.push("</dublincore>")
-  dublincore = dublincore.join("\n")
-
-  # Create nokogiri doc
-  doc = Nokogiri::XML(dublincore)
-  node_set = Nokogiri::XML::NodeSet.new(doc)
-
-  # Create nokogiri nodes
-  node_set << nokogiri_node_creator(doc, 'dcterms:title', dc_data[:title])
-  node_set << nokogiri_node_creator(doc, 'dcterms:identifier', dc_data[:identifier])      if dc_data[:identifier]
-  node_set << nokogiri_node_creator(doc, 'dcterms:creator', dc_data[:creator])            if dc_data[:creator]
-  node_set << nokogiri_node_creator(doc, 'dcterms:isPartOf', dc_data[:isPartOf])          if dc_data[:isPartOf]
-  node_set << nokogiri_node_creator(doc, 'dcterms:contributor', dc_data[:contributor])    if dc_data[:contributor]
-  node_set << nokogiri_node_creator(doc, 'dcterms:subject', dc_data[:subject])            if dc_data[:subject]
-  node_set << nokogiri_node_creator(doc, 'dcterms:language', dc_data[:language])          if dc_data[:language]
-  node_set << nokogiri_node_creator(doc, 'dcterms:description', dc_data[:description])    if dc_data[:description]
-  node_set << nokogiri_node_creator(doc, 'dcterms:spatial', dc_data[:spatial])            if dc_data[:spatial]
-  node_set << nokogiri_node_creator(doc, 'dcterms:created', dc_data[:created])            if dc_data[:created]
-  node_set << nokogiri_node_creator(doc, 'dcterms:rightsHolder', dc_data[:rightsHolder])  if dc_data[:rightsHolder]
-  node_set << nokogiri_node_creator(doc, 'dcterms:license', dc_data[:license])            if dc_data[:license]
-  node_set << nokogiri_node_creator(doc, 'dcterms:publisher', dc_data[:publisher])        if dc_data[:publisher]
-  node_set << nokogiri_node_creator(doc, 'dcterms:temporal', dc_data[:temporal])          if dc_data[:temporal]
-  node_set << nokogiri_node_creator(doc, 'dcterms:source', dc_data[:source])              if dc_data[:source]
-
-  # Add nodes
-  doc.root.add_child(node_set)
-
-  # Finalize
-  return doc.to_xml
-end
-
-#
 # Creates a JSON for sending cutting marks
 #
 # path: Location to save JSON to, string
@@ -399,464 +341,6 @@ def createCuttingMarksJSONAtPath(path, recordingStart, recordingStop, real_start
   end
 
   File.write(path, JSON.pretty_generate(tmpTimes))
-end
-
-#
-# Sends a web request to Opencast, using the credentials defined at the top
-#
-# method: Http method, symbol (e.g. :get, :post)
-# url: ingest method, string (e.g. '/ingest/addPartialTrack')
-# timeout: seconds until request returns with a timeout, numeric
-# payload: information necessary for the request, hash
-#
-# return: The web request response
-#
-def requestIngestAPI(method, url, timeout, payload, additionalErrorMessage="")
-  begin
-    response = RestClient::Request.new(
-      :method => method,
-      :url => $oc_server + url,
-      :user => $oc_user,
-      :password => $oc_password,
-      :timeout => timeout,
-      :payload => payload
-    ).execute
-  rescue RestClient::Exception => e
-    BigBlueButton.logger.error(" A problem occured for request: #{url}")
-    BigBlueButton.logger.info( e)
-    BigBlueButton.logger.info( e.http_body)
-    BigBlueButton.logger.info( additionalErrorMessage)
-    exit 1
-  end
-
-  return response
-end
-
-#
-# Helper function that determines if the metadata in question exists
-#
-# metadata: hash (string => string)
-# metadata_name: string, the key we hope exists in metadata
-# fallback: object, what to return if it doesn't (or is empty)
-#
-# return: the value corresponding to metadata_name or fallback
-#
-def parseMetadataFieldOrFallback(metadata, metadata_name, fallback)
-  return !(metadata[metadata_name.downcase].to_s.empty?) ?
-           metadata[metadata_name.downcase] : fallback
-end
-
-#
-# Creates a definition for metadata, containing symbol, identifier and fallback
-#
-# metadata: hash (string => string)
-# meetingStartTime: time, as a fallback for the "created" metadata-field
-#
-# return: array of hashes
-#
-def getDcMetadataDefinition(metadata, meetingStartTime, meetingEndTime)
-  dc_metadata_definition = []
-  dc_metadata_definition.push( { :symbol   => :title,
-                                 :fullName => "opencast-dc-title",
-                                 :fallback => metadata['meetingname']})
-  dc_metadata_definition.push( { :symbol   => :identifier,
-                                 :fullName => "opencast-dc-identifier",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :creator,
-                                 :fullName => "opencast-dc-creator",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :isPartOf,
-                                 :fullName => "opencast-dc-ispartof",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :contributor,
-                                 :fullName => "opencast-dc-contributor",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :subject,
-                                 :fullName => "opencast-dc-subject",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :language,
-                                 :fullName => "opencast-dc-language",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :description,
-                                 :fullName => "opencast-dc-description",
-                                 :fallback => $useSharedNotesForDescriptionFallback ?
-                                              sharedNotesToString(SHARED_NOTES_PATH) : nil})
-  dc_metadata_definition.push( { :symbol   => :spatial,
-                                 :fullName => "opencast-dc-spatial",
-                                 :fallback => "BigBlueButton"})
-  dc_metadata_definition.push( { :symbol   => :created,
-                                 :fullName => "opencast-dc-created",
-                                 :fallback => meetingStartTime})
-  dc_metadata_definition.push( { :symbol   => :rightsHolder,
-                                 :fullName => "opencast-dc-rightsholder",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :license,
-                                 :fullName => "opencast-dc-license",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :publisher,
-                                 :fullName => "opencast-dc-publisher",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :temporal,
-                                 :fullName => "opencast-dc-temporal",
-                                 :fallback => "start=#{Time.at(meetingStartTime / 1000).to_datetime};
-                                               end=#{Time.at(meetingEndTime / 1000).to_datetime};
-                                               scheme=W3C-DTF"})
-  dc_metadata_definition.push( { :symbol   => :source,
-                                 :fullName => "opencast-dc-source",
-                                 :fallback => $passIdentifierAsDcSource ?
-                                              metadata["opencast-dc-identifier"] : nil })
-  return dc_metadata_definition
-end
-
-#
-# Creates a definition for metadata, containing symbol, identifier and fallback
-#
-# metadata: hash (string => string)
-# meetingStartTime: time, as a fallback for the "created" metadata-field
-#
-# return: array of hashes
-#
-def getSeriesDcMetadataDefinition(metadata, meetingStartTime)
-  dc_metadata_definition = []
-  dc_metadata_definition.push( { :symbol   => :title,
-                                 :fullName => "opencast-series-dc-title",
-                                 :fallback => metadata['meetingname']})
-  dc_metadata_definition.push( { :symbol   => :identifier,
-                                 :fullName => "opencast-dc-isPartOf",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :creator,
-                                 :fullName => "opencast-series-dc-creator",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :contributor,
-                                 :fullName => "opencast-series-dc-contributor",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :subject,
-                                 :fullName => "opencast-series-dc-subject",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :language,
-                                 :fullName => "opencast-series-dc-language",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :description,
-                                 :fullName => "opencast-series-dc-description",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :rightsHolder,
-                                 :fullName => "opencast-series-dc-rightsholder",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :license,
-                                 :fullName => "opencast-series-dc-license",
-                                 :fallback => nil})
-  dc_metadata_definition.push( { :symbol   => :publisher,
-                                 :fullName => "opencast-series-dc-publisher",
-                                 :fallback => nil})
-  return dc_metadata_definition
-end
-
-#
-# Parses dublincore-relevant information from the metadata
-# Contains the definitions for metadata-field-names
-# Casts metadata keys to LOWERCASE
-#
-# metadata: hash (string => string)
-#
-# return hash (symbol => object)
-#
-def parseDcMetadata(metadata, dc_metadata_definition)
-  dc_data = {}
-
-  dc_metadata_definition.each do |definition|
-    dc_data[definition[:symbol]] = parseMetadataFieldOrFallback(metadata, definition[:fullName], definition[:fallback])
-  end
-
-  return dc_data
-end
-
-#
-# Checks if the given identifier is valid to be used for an Opencast event
-#
-# identifier: string, to be used as the UID for an Opencast event
-#
-# Returns the identifier if it is valid, nil if not
-#
-def checkEventIdentifier(identifier)
-  # Check for nil & empty
-  if identifier.to_s.empty?
-    return nil
-  end
-
-  # Check for UUID conformity
-  uuid_regex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-  if !(identifier.to_s.downcase =~ uuid_regex)
-    BigBlueButton.logger.info( "The given identifier <#{identifier}> is not a valid UUID. Will be using generated UUID instead.")
-    return nil
-  end
-
-  # Check for existence in Opencast
-  existsInOpencast = true
-  begin
-    response = RestClient::Request.new(
-      :method => :get,
-      :url => $oc_server + "/api/events/" + identifier,
-      :user => $oc_user,
-      :password => $oc_password,
-    ).execute
-  rescue RestClient::Exception => e
-    existsInOpencast = false
-  end
-  if existsInOpencast
-    BigBlueButton.logger.info( "The given identifier <#{identifier}> already exists within Opencast. Will be using generated UUID instead.")
-    return nil
-  end
-
-  return identifier
-end
-
-#
-# Returns the metadata tags defined for user access list
-#
-# return: hash
-#
-def getAclMetadataDefinition()
-  return {:readRoles => "opencast-acl-read-roles",
-          :writeRoles => "opencast-acl-write-roles",
-          :userIds => "opencast-acl-user-id"}
-end
-
-#
-# Returns the metadata tags defined for series access list
-#
-# return: hash
-#
-def getSeriesAclMetadataDefinition()
-  return {:readRoles => "opencast-series-acl-read-roles",
-          :writeRoles => "opencast-series-acl-write-roles",
-          :userIds => "opencast-series-acl-user-id"}
-end
-
-#
-# Parses acl-relevant information from the metadata
-#
-# metadata: hash (string => string)
-#
-# return array of hash (symbol => string, symbol => string)
-#
-def parseAclMetadata(metadata, acl_metadata_definition, defaultReadRoles, defaultWriteRoles)
-  acl_data = []
-
-  # Read from global, configured-by-user variable
-  defaultReadRoles.to_s.split(",").each do |role|
-    acl_data.push( { :user => role, :permission => "read" } )
-  end
-  defaultWriteRoles.to_s.split(",").each do |role|
-    acl_data.push( { :user => role, :permission => "write" } )
-  end
-
-  # Read from Metadata
-  metadata[acl_metadata_definition[:readRoles]].to_s.split(",").each do |role|
-    acl_data.push( { :user => role, :permission => "read" } )
-  end
-  metadata[acl_metadata_definition[:writeRoles]].to_s.split(",").each do |role|
-    acl_data.push( { :user => role, :permission => "write" } )
-  end
-
-  metadata[acl_metadata_definition[:userIds]].to_s.split(",").each do |userId|
-    acl_data.push( { :user => "ROLE_USER_#{userId}", :permission => "read" } )
-    acl_data.push( { :user => "ROLE_USER_#{userId}", :permission => "write" } )
-  end
-
-  return acl_data
-end
-
-#
-# Creates a xml using the given role information
-#
-# roles: array of hash (symbol => string, symbol => string), containing user role and permission
-#
-# returns: string, the xml
-#
-def createAcl(roles)
-  header = Nokogiri::XML('<?xml version = "1.0" encoding = "UTF-8" standalone ="yes"?>')
-  builder = Nokogiri::XML::Builder.with(header) do |xml|
-    xml.Policy('PolicyId' => 'mediapackage-1',
-    'RuleCombiningAlgId' => 'urn:oasis:names:tc:xacml:1.0:rule-combining-algorithm:permit-overrides',
-    'Version' => '2.0',
-    'xmlns' => 'urn:oasis:names:tc:xacml:2.0:policy:schema:os') {
-      roles.each do |role|
-        xml.Rule('RuleId' => "#{role[:user]}_#{role[:permission]}_Permit", 'Effect' => 'Permit') {
-          xml.Target {
-            xml.Actions {
-              xml.Action {
-                xml.ActionMatch('MatchId' => 'urn:oasis:names:tc:xacml:1.0:function:string-equal') {
-                  xml.AttributeValue('DataType' => 'http://www.w3.org/2001/XMLSchema#string') { xml.text(role[:permission]) }
-                  xml.ActionAttributeDesignator('AttributeId' => 'urn:oasis:names:tc:xacml:1.0:action:action-id',
-                  'DataType' => 'http://www.w3.org/2001/XMLSchema#string')
-                }
-              }
-            }
-          }
-          xml.Condition{
-            xml.Apply('FunctionId' => 'urn:oasis:names:tc:xacml:1.0:function:string-is-in') {
-              xml.AttributeValue('DataType' => 'http://www.w3.org/2001/XMLSchema#string') { xml.text(role[:user]) }
-              xml.SubjectAttributeDesignator('AttributeId' => 'urn:oasis:names:tc:xacml:2.0:subject:role',
-              'DataType' => 'http://www.w3.org/2001/XMLSchema#string')
-            }
-          }
-        }
-      end
-    }
-  end
-
-  return builder.to_xml
-end
-
-#
-# Creates a xml using the given role information
-#
-# roles: array of hash (symbol => string, symbol => string), containing user role and permission
-#
-# returns: string, the xml
-#
-def createSeriesAcl(roles)
-  header = Nokogiri::XML('<?xml version = "1.0" encoding = "UTF-8" standalone ="yes"?>')
-  builder = Nokogiri::XML::Builder.with(header) do |xml|
-    xml.acl('xmlns' => 'http://org.opencastproject.security') {
-      roles.each do |role|
-        xml.ace {
-          xml.action { xml.text(role[:permission]) }
-          xml.allow { xml.text('true') }
-          xml.role { xml.text(role[:user]) }
-        }
-      end
-    }
-  end
-
-  return builder.to_xml
-end
-
-#
-# Recursively check if 2 Nokogiri nodes are the same
-# Does not check for attributes
-#
-# node1: The first Nokogiri node
-# node2: The second Nokogori node
-#
-# returns: boolean, true if the nodes are equal
-#
-def sameNodes?(node1, node2, truthArray=[])
-	if node1.nil? || node2.nil?
-		return false
-	end
-	if node1.name != node2.name
-		return false
-	end
-  if node1.text != node2.text
-          return false
-  end
-	node1Attrs = node1.attributes
-	node2Attrs = node2.attributes
-	node1Kids = node1.children
-	node2Kids = node2.children
-	node1Kids.zip(node2Kids).each do |pair|
-		truthArray << sameNodes?(pair[0],pair[1])
-	end
-	# if every value in the array is true, then the nodes are equal
-	return truthArray.all?
-end
-
-#
-# Extends a series ACL with given roles, if those roles are not already part of the ACL
-#
-# xml: A parsable xml string
-# roles: array of hash (symbol => string, symbol => string), containing user role and permission
-#
-# returns:
-#
-def updateSeriesAcl(xml, roles)
-
-  doc = Nokogiri::XML(xml)
-  newNodeSet = Nokogiri::XML::NodeSet.new(doc)
-
-  roles.each do |role|
-    newNode = nokogiri_node_creator(doc, "ace", "")
-    newNode << nokogiri_node_creator(doc, "action", role[:permission])
-    newNode <<  nokogiri_node_creator(doc, "allow", 'true')
-    newNode <<  nokogiri_node_creator(doc, "role", role[:user])
-
-    # Avoid adding duplicate nodes
-    nodeAlreadyExists = false
-    doc.xpath("//x:ace", "x" => "http://org.opencastproject.security").each do |oldNode|
-      if sameNodes?(oldNode, newNode)
-        nodeAlreadyExists = true
-        break
-      end
-    end
-
-    if (!nodeAlreadyExists)
-      newNodeSet << newNode
-    end
-  end
-
-  doc.root << newNodeSet
-
-  return doc.to_xml
-end
-
-#
-# Will create a new series with the given Id, if such a series does not yet exist
-# Else will try to update the ACL of the series
-#
-# createSeriesId: string, the UID for the new series
-#
-def createSeries(createSeriesId, meeting_metadata, real_start_time)
-  BigBlueButton.logger.info( "Attempting to create a new series...")
-  # Check if a series with the given identifier does already exist
-  seriesExists = false
-  seriesFromOc = requestIngestAPI(:get, '/series/allSeriesIdTitle.json', DEFAULT_REQUEST_TIMEOUT, {})
-  begin
-    seriesFromOc = JSON.parse(seriesFromOc)
-    seriesFromOc["series"].each do |serie|
-      BigBlueButton.logger.info( "Found series: " + serie["identifier"].to_s)
-      if (serie["identifier"].to_s === createSeriesId.to_s)
-        seriesExists = true
-        BigBlueButton.logger.info( "Series already exists")
-        break
-      end
-    end
-  rescue JSON::ParserError  => e
-    BigBlueButton.logger.warn(" Could not parse series JSON, Exception #{e}")
-  end
-
-  # Create Series
-  if (!seriesExists)
-    BigBlueButton.logger.info( "Create a new series with ID " + createSeriesId)
-    # Create Series-DC
-    seriesDcData = parseDcMetadata(meeting_metadata, getSeriesDcMetadataDefinition(meeting_metadata, real_start_time))
-    seriesDublincore = createDublincore(seriesDcData)
-    # Create Series-ACL
-    seriesAcl = createSeriesAcl(parseAclMetadata(meeting_metadata, getSeriesAclMetadataDefinition(),
-                  $defaultSeriesRolesWithReadPerm, $defaultSeriesRolesWithWritePerm))
-    BigBlueButton.logger.info( "seriesAcl: " + seriesAcl.to_s)
-
-    requestIngestAPI(:post, '/series/', DEFAULT_REQUEST_TIMEOUT,
-    { :series => seriesDublincore,
-      :acl => seriesAcl,
-      :override => false})
-
-  # Update Series ACL
-  else
-    BigBlueButton.logger.info( "Updating series ACL...")
-    seriesAcl = requestIngestAPI(:get, '/series/' + createSeriesId + '/acl.xml', DEFAULT_REQUEST_TIMEOUT, {})
-    roles = parseAclMetadata(meeting_metadata, getSeriesAclMetadataDefinition(), $defaultSeriesRolesWithReadPerm, $defaultSeriesRolesWithWritePerm)
-
-    if (roles.length > 0)
-      updatedSeriesAcl = updateSeriesAcl(seriesAcl, roles)
-      requestIngestAPI(:post, '/series/' + createSeriesId + '/accesscontrol', DEFAULT_REQUEST_TIMEOUT,
-        { :acl => updatedSeriesAcl,
-          :override => false})
-      BigBlueButton.logger.info( "Updated series ACL")
-    else
-      BigBlueButton.logger.info( "Nothing to update ACL with")
-    end
-  end
 end
 
 #
@@ -901,8 +385,9 @@ def monitorOpencastWorkflow(ingestResponse, secondsBetweenChecks, secondsUntilGi
     sleep(secondsBetweenChecks)
 
     # Request check
-    response = requestIngestAPI(:get, '/workflow/instance/' + workflowID + '.xml', DEFAULT_REQUEST_TIMEOUT, {},
-                                "There has been a problem in OC with the workflow for mediapackage " + mediapackageID + " for BBB recording " + meetingId + ". Aborting..." )
+    response = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                :get, '/workflow/instance/' + workflowID + '.xml', DEFAULT_REQUEST_TIMEOUT, {},
+                "There has been a problem in OC with the workflow for mediapackage " + mediapackageID + " for BBB recording " + meetingId + ". Aborting..." )
 
     # Request workflow information
     doc = Nokogiri::XML(response)
@@ -1098,24 +583,22 @@ BigBlueButton.logger.info( "Sorted tracks: ")
 BigBlueButton.logger.info( tracks)
 
 # Create metadata file dublincore
-dc_data = parseDcMetadata(meeting_metadata, getDcMetadataDefinition(meeting_metadata, recordingStart.first, recordingStop.last))
-dc_data[:identifier] = checkEventIdentifier(dc_data[:identifier])
-dublincore = createDublincore(dc_data)
+dc_data = OcDublincore::parseDcMetadata(meeting_metadata, server: $oc_server, user: $oc_user, password: $oc_password)
+dublincore = OcDublincore::createDublincore(dc_data)
 BigBlueButton.logger.info( "Dublincore: \n" + dublincore.to_s)
 
 # Create Json containing cutting marks at path
 createCuttingMarksJSONAtPath(CUTTING_JSON_PATH, recordingStart, recordingStop, real_start_time, real_end_time)
 
 # Create ACLs at path
-aclData = parseAclMetadata(meeting_metadata, getAclMetadataDefinition(), $defaultRolesWithReadPerm, $defaultRolesWithWritePerm)
+aclData = OcAcl::parseEpisodeAclMetadata(meeting_metadata, $defaultRolesWithReadPerm, $defaultRolesWithWritePerm)
 if (!aclData.nil? && !aclData.empty?)
-  File.write(ACL_PATH, createAcl(parseAclMetadata(meeting_metadata, getAclMetadataDefinition(), $defaultRolesWithReadPerm, $defaultRolesWithWritePerm)))
+  File.write(ACL_PATH, OcAcl::createAcl(aclData))
 end
 
 # Create series with given seriesId, if such a series does not yet exist
-createSeriesId = meeting_metadata["opencast-dc-ispartof"]
-if ($createNewSeriesIfItDoesNotYetExist && !createSeriesId.to_s.empty?)
-  createSeries(createSeriesId, meeting_metadata, real_start_time)
+if ($createNewSeriesIfItDoesNotYetExist)
+  OcAcl::createSeries(meeting_metadata, $oc_server, $oc_user, $oc_password, $defaultSeriesRolesWithReadPerm, $defaultSeriesRolesWithWritePerm)
 end
 
 #
@@ -1124,9 +607,11 @@ end
 
 # Create Mediapackage
 if !dc_data[:identifier].to_s.empty?
-  mediapackage = requestIngestAPI(:put, '/ingest/createMediaPackageWithID/' + dc_data[:identifier], DEFAULT_REQUEST_TIMEOUT,{})
+  mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                  :put, '/ingest/createMediaPackageWithID/' + dc_data[:identifier], DEFAULT_REQUEST_TIMEOUT,{})
 else
-  mediapackage = requestIngestAPI(:get, '/ingest/createMediaPackage', DEFAULT_REQUEST_TIMEOUT, {})
+  mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                  :get, '/ingest/createMediaPackage', DEFAULT_REQUEST_TIMEOUT, {})
 end
 BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
 # Get mediapackageId for debugging
@@ -1135,7 +620,8 @@ mediapackageId = doc.xpath("/*")[0].attr('id')
 # Add Partial Track
 tracks.each do |track|
   BigBlueButton.logger.info( "Track: " + track.to_s)
-  mediapackage = requestIngestAPI(:post, '/ingest/addPartialTrack', DEFAULT_REQUEST_TIMEOUT,
+  mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                  :post, '/ingest/addPartialTrack', DEFAULT_REQUEST_TIMEOUT,
                   { :flavor => track[:flavor],
                     :startTime => track[:startTime],
                     :mediaPackage => mediapackage,
@@ -1143,12 +629,14 @@ tracks.each do |track|
   BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
 end
 # Add dublincore
-mediapackage = requestIngestAPI(:post, '/ingest/addDCCatalog', DEFAULT_REQUEST_TIMEOUT,
+mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                :post, '/ingest/addDCCatalog', DEFAULT_REQUEST_TIMEOUT,
                 {:mediaPackage => mediapackage,
                  :dublinCore => dublincore })
 BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
 # Add cutting marks
-mediapackage = requestIngestAPI(:post, '/ingest/addCatalog', DEFAULT_REQUEST_TIMEOUT,
+mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                :post, '/ingest/addCatalog', DEFAULT_REQUEST_TIMEOUT,
                 {:mediaPackage => mediapackage,
                  :flavor => CUTTING_MARKS_FLAVOR,
                  :body => File.open(CUTTING_JSON_PATH, 'rb')})
@@ -1157,7 +645,8 @@ mediapackage = requestIngestAPI(:post, '/ingest/addCatalog', DEFAULT_REQUEST_TIM
 BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
 # Add ACL
 if (File.file?(ACL_PATH))
-  mediapackage = requestIngestAPI(:post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
+  mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                  :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
                   {:mediaPackage => mediapackage,
                   :flavor => "security/xacml+episode",
                   :body => File.open(ACL_PATH, 'rb') })
@@ -1166,7 +655,8 @@ else
   BigBlueButton.logger.info( "No ACL found, skipping adding ACL.")
 end
 # Ingest and start workflow
-response = requestIngestAPI(:post, '/ingest/ingest/' + $oc_workflow, START_WORKFLOW_REQUEST_TIMEOUT,
+response = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                :post, '/ingest/ingest/' + $oc_workflow, START_WORKFLOW_REQUEST_TIMEOUT,
                 { :mediaPackage => mediapackage },
                 "LOG ERROR Aborting ingest with BBB id " + meeting_id + "and OC id" + mediapackageId )
 BigBlueButton.logger.info( response)

--- a/post-publish/README.md
+++ b/post-publish/README.md
@@ -10,8 +10,14 @@ The Idea
 - Send them to Opencast once they are finished
 - Transferred media includes:
     - Combined video of all webcams
-	 - Video of Screen recording
-	 - Combined audio
+    - Video of Screen recording
+    - Combined audio
+    
+Requirements
+------------
+
+- The Ruby gem 'rest-client' is used to send requests to Opencast. If it is not yet installed, manually install it
+  via `gem install *name*`.
 
 
 The Integration Script
@@ -24,6 +30,11 @@ This script should be located at (there should already be an example script in t
 
 Make sure to adjust the credentials set at the top of this script.
 
+Place the folder `oc_modules` from the top-level of this repository in the same location as the script. It contains
+modules that are necessary for the script to run.
+
+    /usr/local/bigbluebutton/core/scripts/post_publish/oc_modules
+
 
 Limitations
 -----------
@@ -31,6 +42,5 @@ Limitations
 This is a very simple integration, but should work just fine.
 Nevertheless, there are a few limitations.
 
-- Right now, only the room name is added as metadata to the recording.
 - BigBlueButton includes audio only in the camera recording, not in the screen recording.
   Your Opencast workflow will need to fix that.

--- a/post-publish/post_publish.rb
+++ b/post-publish/post_publish.rb
@@ -22,29 +22,51 @@
 
 require "shellwords"
 require "trollop"
+require 'nokogiri'        #XML-Parser
 require File.expand_path('../../../lib/recordandplayback', __FILE__)
 
-opts = Trollop::options do
-  opt :meeting_id, "Meeting id to archive", :type => String
-end
-meeting_id = opts[:meeting_id]
+require_relative 'oc_modules/oc_dublincore'
+require_relative 'oc_modules/oc_acl'
+require_relative 'oc_modules/oc_util'
 
 ### opencast configuration begin
 
 # Server URL
 # oc_server = 'https://develop.opencast.org'
-oc_server = 'https://develop.opencast.org'
+oc_server = '{{opencast_server}}'
 
 # User credentials allowed to ingest via HTTP basic
 # oc_user = 'username:password'
-oc_user = 'admin:opencast'
+oc_user = 'admin'
+oc_password = 'opencast'
 
 # Workflow to use for ingest
 # oc_workflow = 'schedule-and-upload'
 oc_workflow = 'schedule-and-upload'
 
+# Default roles for the event, e.g. "ROLE_OAUTH_USER, ROLE_USER_BOB"
+# Suggested default: ""
+defaultRolesWithReadPerm = ""
+defaultRolesWithWritePerm = ""
+
+# Whether a new series should be created if the given one does not exist yet
+# Suggested default: false
+createNewSeriesIfItDoesNotYetExist = true
+
+# Default roles for the series, e.g. "ROLE_OAUTH_USER, ROLE_USER_BOB"
+# Suggested default: ""
+defaultSeriesRolesWithReadPerm = ""
+defaultSeriesRolesWithWritePerm = ""
+
 ### opencast configuration end
 
+#
+# Parse cmd args from BBB and initialize logger
+
+opts = Trollop::options do
+ opt :meeting_id, "Meeting id to archive", :type => String
+end
+meeting_id = opts[:meeting_id]
 
 logger = Logger.new("/var/log/bigbluebutton/post_publish.log", 'weekly' )
 logger.level = Logger::INFO
@@ -53,31 +75,94 @@ BigBlueButton.logger = logger
 published_files = "/var/bigbluebutton/published/presentation/#{meeting_id}"
 meeting_metadata = BigBlueButton::Events.get_meeting_metadata("/var/bigbluebutton/recording/raw/#{meeting_id}/events.xml")
 
-#
-# Put your code here
-#
-BigBlueButton.logger.info("Upload Recording for [#{meeting_id}]...")
+# Variables
+DEFAULT_REQUEST_TIMEOUT = 10                                  # Http request timeout in seconds
+START_WORKFLOW_REQUEST_TIMEOUT = 6000                         # Specific timeout; Opencast runs MediaInspector on every file, which can take quite a while
+ACL_PATH = File.join(published_files, "acl.xml")
 
-ingest = false
-presenter = ''
-presentation = ''
-title = Shellwords.escape(meeting_metadata['meetingName'])
-oc_user = Shellwords.escape(oc_user)
+BigBlueButton.logger.info( "Prepare Metadata for [#{meeting_id}]...")
 
+# Create metadata file dublincore
+dc_data = OcDublincore::parseDcMetadata(meeting_metadata, server: oc_server, user: oc_user, password: oc_password)
+dublincoreXML = OcDublincore::createDublincore(dc_data)
+BigBlueButton.logger.info( "Dublincore: \n" + dublincoreXML.to_s)
+
+# Create ACLs at path
+aclData = OcAcl::parseEpisodeAclMetadata(meeting_metadata, $defaultRolesWithReadPerm, $defaultRolesWithWritePerm)
+if (!aclData.nil? && !aclData.empty?)
+  File.write(ACL_PATH, OcAcl::createAcl(aclData))
+end
+
+# Create series with given seriesId, if such a series does not yet exist
+if (createNewSeriesIfItDoesNotYetExist)
+  OcAcl::createSeries(meeting_metadata, oc_server, oc_user, oc_password, defaultSeriesRolesWithReadPerm, defaultSeriesRolesWithWritePerm)
+end
+
+#
+# Create a mediapackage and ingest it
+#
+
+BigBlueButton.logger.info( "Upload Recording for [#{meeting_id}]...")
+
+# Create Mediapackage
+if !dc_data[:identifier].to_s.empty?
+  mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+    :put, '/ingest/createMediaPackageWithID/' + dc_data[:identifier], DEFAULT_REQUEST_TIMEOUT, {}
+  )
+else
+  mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+    :get, '/ingest/createMediaPackage', DEFAULT_REQUEST_TIMEOUT, {}
+  )
+end
+
+# Get mediapackageId for debugging
+doc = Nokogiri::XML(mediapackage)
+mediapackageId = doc.xpath("/*")[0].attr('id')
+
+# Add Track
 if (File.exists?(published_files + '/video/webcams.webm'))
-  BigBlueButton.logger.info("Found presenter video")
-  ingest = true
-  presenter = "-F 'flavor=presentater/source' -F 'BODY1=@#{published_files + '/video/webcams.webm'}'"
+  BigBlueButton.logger.info( "Found presenter video")
+  mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+                  :post, '/ingest/addPartialTrack', DEFAULT_REQUEST_TIMEOUT,
+                  { :flavor => 'presenter/source',
+                    :mediaPackage => mediapackage,
+                    :body => File.open(published_files + '/video/webcams.webm', 'rb') })
 end
 if (File.exists?(published_files + '/deskshare/deskshare.webm'))
-  BigBlueButton.logger.info("Found presentation video")
-  ingest = true
-  presentation = "-F 'flavor=presentation/source' -F 'BODY2=@#{published_files + '/deskshare/deskshare.webm'}'"
+  BigBlueButton.logger.info( "Found presentation video")
+  mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+                  :post, '/ingest/addPartialTrack', DEFAULT_REQUEST_TIMEOUT,
+                  { :flavor => 'presentation/source',
+                    :mediaPackage => mediapackage,
+                    :body => File.open(published_files + '/deskshare/deskshare.webm', 'rb') })
 end
-if (ingest)
-  BigBlueButton.logger.info("Uploading...")
-  puts `curl -u '#{oc_user}' "#{oc_server}/ingest/addMediaPackage/#{oc_workflow}" #{presenter} #{presentation} -F title="#{title}"`
+
+# Add dublincore
+mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+                :post, '/ingest/addDCCatalog', DEFAULT_REQUEST_TIMEOUT,
+                {:mediaPackage => mediapackage,
+                 :dublinCore => dublincoreXML })
+
+# Add ACL if applicable
+if (File.file?(ACL_PATH))
+  mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+                  :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
+                  {:mediaPackage => mediapackage,
+                  :flavor => "security/xacml+episode",
+                  :body => File.open(ACL_PATH, 'rb') })
+else
+  BigBlueButton.logger.info( "No ACL found, skipping adding ACL.")
 end
-BigBlueButton.logger.info("Upload for [#{meeting_id}] ends")
+
+# Ingest and start workflow
+BigBlueButton.logger.info( "Uploading...")
+response = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
+                :post, '/ingest/ingest/' + oc_workflow, START_WORKFLOW_REQUEST_TIMEOUT,
+                { :mediaPackage => mediapackage },
+                "LOG ERROR Aborting ingest with BBB id #{meeting_id} and OC id #{mediapackageId}")
+BigBlueButton.logger.info( "Upload for [#{meeting_id}] ends")
+
+# Remove temporary files
+File.delete(ACL_PATH)
 
 exit 0


### PR DESCRIPTION
Users of the post_publish script will now be able to pass metadata to Opencast in the same way as the post_archive script. This implicitly fixes the repository documentation, which never specified that passing metadata only worked for the post_archive integration.

To that end, the metadata-related code was outsourced into three modules in the new folder `oc_modules`. Both post processing scripts now require the presence of this folder to function.

The post_publish script was expanded to use the new modules. Furthermore, the single web-request to `/ingest/addMediapackage{wID}` was replaced by multiple web-requests (using the 'rest-client' gem), as the aforementioned endpoint does not offer a form field for ACLs.

Resolves #1.