### PR TITLE
Chat can now be send to Opencast as a subtitle file

### DIFF
--- a/post-archive/README.md
+++ b/post-archive/README.md
@@ -4,6 +4,7 @@ Post-Archive Integration
 **There is a known bug where the final video in Opencast will be too short due to missing parts of the recording. A
   workaround is currently not available for Opencast 8!!!, but will be available with Opencast 9.**
 - If you wish to have the workaround available in Opencast 8, you will have to backport [Opencast Pull Request #1898](https://github.com/opencast/opencast/pull/1898)
+    - You will also have to uncomment two lines in the `bbb-upload.xml`
 
 The Idea
 --------

--- a/post-archive/README.md
+++ b/post-archive/README.md
@@ -4,7 +4,6 @@ Post-Archive Integration
 **There is a known bug where the final video in Opencast will be too short due to missing parts of the recording. A
   workaround is currently not available for Opencast 8!!!, but will be available with Opencast 9.**
 - If you wish to have the workaround available in Opencast 8, you will have to backport [Opencast Pull Request #1898](https://github.com/opencast/opencast/pull/1898)
-    - You will also have to uncomment two lines in the `bbb-upload.xml`
 
 The Idea
 --------

--- a/post-archive/bbb-upload.xml
+++ b/post-archive/bbb-upload.xml
@@ -53,6 +53,21 @@
       </configurations>
     </operation>
 
+    <!--- Tag captions for publish to engage -->
+
+    <operation
+        id="tag"
+        max-attempts="2"
+        fail-on-error="true"
+        exception-handler-workflow="error"
+        description="Tagging captions for publishing to engage">
+      <configurations>
+        <configuration key="source-flavors">captions/*</configuration>
+        <configuration key="target-tags">+engage-download</configuration>
+        <configuration key="copy">false</configuration>
+      </configurations>
+    </operation>
+
     <!-- Save source in case of errors -->
 
     <operation

--- a/post-archive/bbb-upload.xml
+++ b/post-archive/bbb-upload.xml
@@ -117,11 +117,9 @@
         <configuration key="concat-encoding-profile">concat.work</configuration>
         <configuration key="trim-encoding-profile">trim.work</configuration>
         <configuration key="force-encoding-profile">editor.work</configuration>
-        <!-- Uncomment the lines below if you backported the PR #1898 -->
-        <!--
+        <!-- Not yet in Opencast! -->
         <configuration key="preencode-encoding">true</configuration>
         <configuration key="preencode-encoding-profile">editor.work</configuration>
-        -->
       </configurations>
     </operation>
 

--- a/post-archive/bbb-upload.xml
+++ b/post-archive/bbb-upload.xml
@@ -117,9 +117,11 @@
         <configuration key="concat-encoding-profile">concat.work</configuration>
         <configuration key="trim-encoding-profile">trim.work</configuration>
         <configuration key="force-encoding-profile">editor.work</configuration>
-        <!-- Not yet in Opencast! -->
+        <!-- Uncomment the lines below if you backported the PR #1898 -->
+        <!--
         <configuration key="preencode-encoding">true</configuration>
         <configuration key="preencode-encoding-profile">editor.work</configuration>
+        -->
       </configurations>
     </operation>
 

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -26,6 +26,10 @@ $oc_workflow = 'bbb-upload'
 # Suggested default: false
 $sendSharedNotesEtherpadAsAttachment = false
 
+# Adds the public chat from a meeting to the attachments in Opencast as a subtitle file
+# Suggested default: false
+$sendChatAsSubtitleAttachment = false
+
 # Default roles for the event, e.g. "ROLE_OAUTH_USER, ROLE_USER_BOB"
 # Suggested default: ""
 $defaultRolesWithReadPerm = '{{opencast_rolesWithReadPerm}}'
@@ -860,6 +864,78 @@ def createSeries(createSeriesId, meeting_metadata, real_start_time)
 end
 
 #
+# Parses the chat messages from the events.xml into a webvtt subtitles file
+# TODO: Sanitize chat messages?
+#
+# doc: file handle
+# chatFilePath: string
+# realStartTime: number, start time of the meeting in epoch time
+# recordingStart: array[string], times when the recording button was pressed in epoch time
+# recordingStop: array[string], times when the recording button was pressed in epoch time
+#
+def parseChat(doc, chatFilePath, realStartTime, recordingStart, recordingStop)
+  BigBlueButton.logger.info( "Parsing chat messages")
+
+  timeFormat = '%H:%M:%S.%L'
+  displayMessageTimeMax = 3  # seconds
+  chatMessages = []
+
+  # Gather messages
+  chatEvents = doc.xpath("//event[@eventname='PublicChatEvent']")
+
+  recordingStart.each.with_index do |recordStartStamp, index|
+    recordStopStamp = recordingStop[index]
+
+    chatEvents.each do |node|
+      chatTimestamp = node.at_xpath("timestampUTC").content.to_i
+
+      if (chatTimestamp >= recordStartStamp.to_i and chatTimestamp <= recordStopStamp.to_i)
+        chatSender = node.xpath(".//sender")[0].text()
+        chatMessage =  node.xpath(".//message")[0].text()
+        chatStart = Time.at((chatTimestamp - realStartTime) / 1000.0) #.utc.strftime(TIME_FORMAT)
+        #chatEnd = Time.at((chatTimestamp - realStartTime) / 1000.0) + 2
+        #chatEnd = chatEnd.utc.strftime(TIME_FORMAT)
+        chatMessages.push({sender: chatSender,
+          message: chatMessage,
+          startTime: chatStart,
+          endTime: Time.at(0)
+        })
+      end
+    end
+
+  end
+
+  # Update timestamps
+  chatMessages.each.with_index do |message, index|
+    # Last message
+    if chatMessages[index + 1].nil?
+      message[:endTime] = message[:startTime] + displayMessageTimeMax
+      break
+    end
+
+    if (chatMessages[index + 1][:startTime] - message[:startTime]) < displayMessageTimeMax
+      message[:endTime] = chatMessages[index + 1][:startTime]
+    else
+      message[:endTime] = message[:startTime] + displayMessageTimeMax
+    end
+  end
+
+  # Compile messages
+  files = []
+  files.push("WEBVTT")
+  files.push("")
+  chatMessages.each do |message|
+    files.push(message[:startTime].utc.strftime(timeFormat).to_s + " --> " + message[:endTime].utc.strftime(timeFormat).to_s)
+    files.push(message[:sender] + ": " + message[:message])
+    files.push("")
+  end
+
+  if (chatMessages.length > 0)
+    File.write(chatFilePath, files.join("\n"))
+  end
+end
+
+#
 # Monitors the state of the started workflow after ingest
 # Will run for quite some time
 #
@@ -969,6 +1045,7 @@ PRESENTATION_PATH = File.join(archived_files, 'presentation')  # Path defined by
 SHARED_NOTES_PATH = File.join(archived_files, 'notes')         # Path defined by BBB
 TMP_PATH = File.join(archived_files, 'upload_tmp')             # Where temporary files can be stored
 CUTTING_JSON_PATH = File.join(TMP_PATH, "cutting.json")
+CHAT_PATH = File.join(TMP_PATH, "chat.vtt")
 ACL_PATH = File.join(TMP_PATH, "acl.xml")
 
 # Create local tmp directory
@@ -1097,6 +1174,11 @@ if ($createNewSeriesIfItDoesNotYetExist && !createSeriesId.to_s.empty?)
   createSeries(createSeriesId, meeting_metadata, real_start_time)
 end
 
+# Create a subtitles file from chat
+if ($sendChatAsSubtitleAttachment)
+  parseChat(doc, CHAT_PATH, real_start_time, recordingStart, recordingStop)
+end
+
 #
 # Create a mediapackage and ingest it
 #
@@ -1153,6 +1235,16 @@ if ($sendSharedNotesEtherpadAsAttachment && File.file?(File.join(SHARED_NOTES_PA
   BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
 else
   BigBlueButton.logger.info( "Adding Shared notes is either disabled or the etherpad was not found, skipping adding Shared Notes Etherpad.")
+end
+# Add Chat as subtitles
+if ($sendChatAsSubtitleAttachment && File.file?(CHAT_PATH))
+  mediapackage = requestIngestAPI(:post, '/ingest/addCatalog', DEFAULT_REQUEST_TIMEOUT,
+                  {:mediaPackage => mediapackage,
+                  :flavor => "captions/vtt+en",
+                  :body => File.open(CHAT_PATH, 'rb') })
+  BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
+else
+  BigBlueButton.logger.info( "Adding Chat as subtitles is either disabled or there was no chat, skipping adding Chat as subtitles.")
 end
 # Ingest and start workflow
 response = requestIngestAPI(:post, '/ingest/ingest/' + $oc_workflow, START_WORKFLOW_REQUEST_TIMEOUT,


### PR DESCRIPTION
This PR parses public chat messages from the events.xml into a subtitles file which can be send to Opencast and be displayed by the Paella Player.

As the Paella Player currently lacks functionality for displaying chat messages (as for example in twitch livestream recordings), displaying the chat as subtitles is the next best thing.

Drawbacks:
- Users cannot easily read past messages
- Rapid-fire messages are difficult to display in a readable way

Missing features:
- Line breaks for long messages