### PR TITLE
Use rsvg-convert instead of ImageMagick's convert.

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -215,7 +215,7 @@ def convertSlidesToVideo(presentationSlidesStart)
       # Convert to png using command line tool rsvg-convert
       image_format = 'png'
       pathToImage = File.join(dirname, changeFileExtensionTo(item["filename"], "png"))
-      `rsvg-convert #{originalLocation} -f #{image_format} -o #{pathToImage}`
+      `rsvg-convert #{originalLocation} -f #{image_format} --width 2560 -o #{pathToImage}`
 
       # Convert to video
       # Scales the output to be divisible by 2

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -2,7 +2,6 @@ require 'trollop'         #Commandline Parser
 require 'rest-client'     #Easier HTTP Requests
 require 'nokogiri'        #XML-Parser
 require 'fileutils'       #Directory Creation
-require 'mini_magick'     #Image Conversion
 require 'streamio-ffmpeg' #Accessing video information
 require File.expand_path('../../../lib/recordandplayback', __FILE__)  # BBB Utilities
 
@@ -213,11 +212,10 @@ def convertSlidesToVideo(presentationSlidesStart)
         FileUtils.mkdir_p(dirname)
       end
 
-      # Convert to png
-      image = MiniMagick::Image.open(originalLocation)
-      image.format 'png'
+      # Convert to png using command line tool rsvg-convert
+      image_format = 'png'
       pathToImage = File.join(dirname, changeFileExtensionTo(item["filename"], "png"))
-      image.write pathToImage
+      `rsvg-convert #{originalLocation} -f #{image_format} -o #{pathToImage}`
 
       # Convert to video
       # Scales the output to be divisible by 2


### PR DESCRIPTION
The slide conversion to PNG seems to not work correctly with ImageMagick on Ubuntu >= 18.04 so I changed the converter to `rsvg-convert` and calling the command line tool directly in the `post-archive.rb` script (this needs the package `librsvg2-bin` installed to work) instead of using the `mini-magick` ruby gem.