### PR TITLE
Fix Upload of Prepared Files

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -249,7 +249,7 @@ def checkForTranscode(path, filename)
 
   if ($doNotConvertVideosAgain && File.exists?(outputPathToFile))
     BigBlueButton.logger.info( "Converted video for #{pathToFile} already exists, skipping...")
-    return path
+    return outputPathToFile
   end
 
   # Gather possible commands


### PR DESCRIPTION
In case files have already been processed to fix odd resolutions, the
integration will skip the work but then accidentally ingest the raw
recoding, not the prepared one.

This patch fixes that problem.