### PR TITLE
Remove potential encoding of screenshare videos

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -612,9 +612,6 @@ presentationSlidesStart = parseTimeStampsPresentation(doc, 'GotoSlideEvent', pre
 presentationSlidesStart = convertSlidesToVideo(presentationSlidesStart)
 
 # Check and process any videos if they need to be prepared before Opencast can process them
-deskshareStart.each do |share|
-  share["filepath"] = checkForTranscode(share["filepath"], share["filename"])
-end
 webcamStart.each do |share|
   share["filepath"] = checkForTranscode(share["filepath"], share["filename"])
 end


### PR DESCRIPTION
Fixing screenshare videos will be done by Opencasts partial-import operation anyway. Related to #14 