### PR TITLE
Suggest archive source material in partial error workflow

### DIFF
--- a/post-archive/README.md
+++ b/post-archive/README.md
@@ -62,6 +62,7 @@ Setup Opencast
 - Add the file `bbb-publish-after-cutting.xml`. This will add a new Publish option to the VideoEditor, which needs to be used when cutting videos after they have been uploaded from BBB.
 - In the Admin-UI, create the user you entered in the post_archive.rb during "Setup BBB"
 - When using Opencast 8.6 or lower: Apply a fix in the file `/etc/encoding/opencast-images.properties` by assigning the variable `profile.import.image-frame.ffmpeg.command` the value `-sseof -3 -i #{in.video.path} -update 1 -q:v 1 #{out.dir}/#{out.name}#{out.suffix}`.
+- Please adjust the snapshot workflow operation in the `partial-error.xml` workflow archiving the flavors `smil/source+partial,etherpad/sharednotes,json/times,captions/*` to avoid source data loss in case of processing errors.
 
 Limitations & Take Cares
 --------


### PR DESCRIPTION
The default partial-error workflow does not include material tagged
smil/source+partial and other source material and it's lost in case of errors.

https://github.com/opencast/opencast/blob/develop/etc/workflows/partial-error.xml#L34