### PR TITLE
Assume white slide background in post archive

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -236,7 +236,7 @@ def convertSlidesToVideo(presentationSlidesStart)
       # Convert to png using command line tool rsvg-convert
       image_format = 'png'
       pathToImage = File.join(dirname, changeFileExtensionTo(item["filename"], "png"))
-      `rsvg-convert #{originalLocation} -f #{image_format} --width 2560 -o #{pathToImage}`
+      `rsvg-convert #{originalLocation} -f #{image_format} --width 2560 --background-color white -o #{pathToImage}`
 
       # Convert to video
       # Scales the output to be divisible by 2


### PR DESCRIPTION
When converting SVGs directly with ffmpeg, the background is assumed to be white
but with rsvg-convert in the pipeline, the background became black by default.

Most slides have a white background.

Without the background set to white:

![image](https://user-images.githubusercontent.com/2311611/117530823-89d5f380-afdf-11eb-877b-6d840230691e.png)

With background set to white (same behaviour as without rsvg-convert):

![image](https://user-images.githubusercontent.com/2311611/117530851-affb9380-afdf-11eb-88e2-806a7e428ff2.png)
