### PR TITLE
Send shared notes also as HTML

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -703,6 +703,15 @@ if ($config.dig(:addFiles, :sharedNotesEtherpadAsAttachment) && File.file?(File.
                   :flavor => "etherpad/sharednotes",
                   :body => File.open(File.join(SHARED_NOTES_PATH, "notes.etherpad"), 'rb') })
   BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
+  if (File.file?(File.join(SHARED_NOTES_PATH, "notes.html")))
+    mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
+                    :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
+                    {:mediaPackage => mediapackage,
+                    :flavor => "html/sharednotes",
+                    :body => File.open(File.join(SHARED_NOTES_PATH, "notes.html"), 'rb') })
+  else
+    BigBlueButton.logger.info( "No HTML source for shared notes found.")
+  end
 else
   BigBlueButton.logger.info( "Adding Shared notes is either disabled or the etherpad was not found, skipping adding Shared Notes Etherpad.")
 end

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -220,7 +220,7 @@ end
 #
 # Checks if the video requires transcoding before sending it to Opencast
 # * Checks if a video has a width and height that is divisible by 2
-#   If not, crops the video to have one 
+#   If not, crops the video to have one
 # * Checks if the video is missing duration metadata
 #   If it's missing, copies the video to add it
 #
@@ -703,18 +703,28 @@ if ($config.dig(:addFiles, :sharedNotesEtherpadAsAttachment) && File.file?(File.
                   :flavor => "etherpad/sharednotes",
                   :body => File.open(File.join(SHARED_NOTES_PATH, "notes.etherpad"), 'rb') })
   BigBlueButton.logger.info( "Mediapackage: \n" + mediapackage)
-  if (File.file?(File.join(SHARED_NOTES_PATH, "notes.html")))
-    mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
-                    :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
-                    {:mediaPackage => mediapackage,
-                    :flavor => "html/sharednotes",
-                    :body => File.open(File.join(SHARED_NOTES_PATH, "notes.html"), 'rb') })
-  else
-    BigBlueButton.logger.info( "No HTML source for shared notes found.")
-  end
 else
   BigBlueButton.logger.info( "Adding Shared notes is either disabled or the etherpad was not found, skipping adding Shared Notes Etherpad.")
 end
+if ($config.dig(:addFiles, :sharedNotesHmtlAsAttachment) && File.file?(File.join(SHARED_NOTES_PATH, "notes.html")))
+  mediapackage = OcUtil::requestIngestAPI($config.dig(:opencast, :server), $config.dig(:opencast, :user), $config.dig(:opencast, :password),
+                  :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
+                  {:mediaPackage => mediapackage,
+                  :flavor => "html/sharednotes",
+                  :body => File.open(File.join(SHARED_NOTES_PATH, "notes.html"), 'rb') })
+else
+  BigBlueButton.logger.info( "No HTML source for shared notes found or disabled.")
+end
+if ($config.dig(:addFiles, :sharedNotesPdfAsAttachment) && File.file?(File.join(SHARED_NOTES_PATH, "notes.pdf")))
+  mediapackage = OcUtil::requestIngestAPI($config.dig(:opencast, :server), $config.dig(:opencast, :user), $config.dig(:opencast, :password),
+                  :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
+                  {:mediaPackage => mediapackage,
+                  :flavor => "pdf/sharednotes",
+                  :body => File.open(File.join(SHARED_NOTES_PATH, "notes.pdf"), 'rb') })
+else
+  BigBlueButton.logger.info( "No PDF source for shared notes found or disabled.")
+end
+
 # Add Chat as subtitles
 if ($config.dig(:addFiles, :chatAsSubtitleAttachment) && File.file?(CHAT_PATH))
   mediapackage = OcUtil::requestIngestAPI($config.dig(:opencast, :server), $config.dig(:opencast, :user), $config.dig(:opencast, :password),

--- a/post-archive/post_archive_config.toml
+++ b/post-archive/post_archive_config.toml
@@ -29,6 +29,14 @@ webcamTracks = true
 # Default: false
 sharedNotesEtherpadAsAttachment = false
 
+# Adds the shared notes as HTML from a meeting to the attachments in Opencast
+# Default: false
+sharedNotesHmtlAsAttachment = false
+
+# Adds the shared notes as PDF from a meeting to the attachments in Opencast
+# Default: false
+sharedNotesPdfAsAttachment = false
+
 # Adds the public chat from a meeting to the attachments in Opencast as a subtitle file
 # Default: false
 chatAsSubtitleAttachment = false


### PR DESCRIPTION
HTML is useful for quickly viewing the shared notes (while the etherpad format is useful for seeing how the shared notes have created and to continue work).