### PR TITLE
Actually send shared notes as an attachment

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -738,7 +738,7 @@ end
 # Add Shared Notes
 if ($sendSharedNotesEtherpadAsAttachment && File.file?(File.join(SHARED_NOTES_PATH, "notes.etherpad")))
   mediapackage = OcUtil::requestIngestAPI($oc_server, $oc_user, $oc_password,
-                  :post, '/ingest/addCatalog', DEFAULT_REQUEST_TIMEOUT,
+                  :post, '/ingest/addAttachment', DEFAULT_REQUEST_TIMEOUT,
                   {:mediaPackage => mediapackage,
                   :flavor => "etherpad/sharednotes",
                   :body => File.open(File.join(SHARED_NOTES_PATH, "notes.etherpad"), 'rb') })


### PR DESCRIPTION
The config option already claimed that shared notes are send as attachments, but in the code they are send as catalogs. This fixes that.

Resolves #28