### PR TITLE
Process audio-only Media to blackscreenvideo with text audio-only

### DIFF
--- a/post-archive/bbb-partial-preview.xml
+++ b/post-archive/bbb-partial-preview.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>bbb-partial-preview</id>
+  <title>Prepare preview artifacts</title>
+  <tags/>
+  <description/>
+  <configuration_panel/>
+
+  <operations>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Preview movies                                                    -->
+    <!--                                                                   -->
+    <!-- Based on the work artifacts, extract preview versions.            -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Transcode video previews -->
+
+    <operation
+      id="analyze-tracks"
+      exception-handler-workflow="partial-error"
+      description="Analyze tracks in media package and set control variables">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+      </configurations>
+    </operation>
+
+    <operation id="compose"
+      description="Create single-stream video preview"
+      if="NOT (${presenter_prepared_video} AND ${presentation_prepared_video})"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavors">*/prepared</configuration>
+        <configuration key="target-flavor">*/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">mp4-preview.http</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="composite"
+      description="Create dual-stream video preview"
+      if="${presenter_prepared_video} AND ${presentation_prepared_video}"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavor-lower">presentation/prepared</configuration>
+        <configuration key="source-flavor-upper">presenter/prepared</configuration>
+        <configuration key="encoding-profile">mp4-preview.dual.http</configuration>
+        <configuration key="target-flavor">composite/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="output-resolution">1280x400</configuration>
+        <configuration key="output-background">0x000000FF</configuration>
+        <configuration key="layout">preview</configuration>
+        <configuration key="layout-preview">
+          {"horizontalCoverage":0.5,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
+          {"horizontalCoverage":0.5,"anchorOffset":{"referring":{"left":0.0,"top":0.0},"reference":{"left":0.0,"top":0.0},"offset":{"x":0,"y":0}}};
+        </configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Audio waveform                                                    -->
+    <!--                                                                   -->
+    <!-- Create the waveform.                                              -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <operation
+      id="waveform"
+      fail-on-error="false"
+      description="Generating waveform">
+      <configurations>
+        <configuration key="source-flavor">*/preview</configuration>
+        <configuration key="target-flavor">*/waveform</configuration>
+        <configuration key="target-tags">preview</configuration>
+      </configurations>
+    </operation>
+
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Track previews                                                    -->
+    <!--                                                                   -->
+    <!-- Create track previews for video editor stream selection feature   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <operation
+      id="image"
+      description="Create video preview images for presenter and presentation"
+      exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="target-flavor">*/video+preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">editor.tracks.preview</configuration>
+        <configuration key="time">50%</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="waveform"
+      fail-on-error="false"
+      description="Generating waveform">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="target-flavor">*/audio+preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="min-width">688</configuration>
+        <configuration key="max-width">688</configuration>
+        <configuration key="height">58</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Extract the thumbnail preview image for the video editor          -->
+    <!-- Depending on the processing settings of the event, this might be  -->
+    <!-- either the default thumbnail, an uploaded thumbnail or a          -->
+    <!-- snapshot thumbnail.                                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Default Thumbnail (0)
+         The default thumbnail needs to be extracted from fixed offset (in seconds) relative to the cutted media.
+         The variable thumbnailPosition contains the respective absolute position relative to the uncutted media
+         so we don't need access to the cutted media for extraction here. -->
+
+    <!-- If we have a presenter track, we extract the default thumbnail from the presenter track -->
+
+    <operation id="image"
+               if="${thumbnailType} == 0 AND ${presenter_prepared_video}"
+               exception-handler-workflow="partial-error"
+               description="Extract default thumbnail preview image from presenter track">
+      <configurations>
+        <configuration key="source-flavor">presenter/prepared</configuration>
+        <configuration key="target-flavor">thumbnail/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <!-- If we don't have a presenter track, but we do have a presentation track, we extract the thumbnail from the
+         presentation track -->
+
+    <operation id="image"
+               if="${thumbnailType} == 0 AND ${presentation_prepared_video} AND NOT (${presenter_prepared_video})"
+              exception-handler-workflow="partial-error"
+              description="Extract thumbnail preview image from presentation track">
+      <configurations>
+        <configuration key="source-flavor">presentation/prepared</configuration>
+        <configuration key="target-flavor">thumbnail/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+        </configurations>
+    </operation>
+
+    <!-- Upload thumbnail (1)
+         The uploaded thumbnail is archived in the media package. We just need to convert the image
+         to a resolution optimized for the video editor here -->
+
+    <operation
+      id="image-convert"
+      description="Convert uploaded thumbnail to thumbnail preview image">
+      <configurations>
+        <configuration key="source-flavors">thumbnail/source</configuration>
+        <configuration key="target-flavor">thumbnail/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profiles">editor.thumbnail.preview.downscale</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Snapshot Thumbnail (2)
+         The snapshot thumbnail is extracted from the flavor type as provided by the variable
+         thumbnailTrack at position thumbnailPosition relative to the uncut media. -->
+
+    <operation id="image"
+               if="${thumbnailType} == 2"
+               exception-handler-workflow="partial-error"
+               description="Extract snapshot thumbnail preview image">
+      <configurations>
+        <configuration key="source-flavor">${thumbnailTrack}/prepared</configuration>
+        <configuration key="target-flavor">thumbnail/preview</configuration>
+        <configuration key="target-tags">preview</configuration>
+        <configuration key="encoding-profile">editor.thumbnail.preview</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Silence detection                                                 -->
+    <!--                                                                   -->
+    <!-- Run silence detection to provide hints to the video editor.       -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Run silence detection -->
+
+    <operation
+      id="silence"
+      fail-on-error="false"
+      description="Detecting silence">
+      <configurations>
+        <configuration key="source-flavors">*/preview</configuration>
+        <configuration key="smil-flavor-subtype">silence</configuration>
+        <configuration key="reference-tracks-flavor">*/prepared</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag the results for internal publishing -->
+    <!-- Fixme: remove once "silence" operation supports target-tags -->
+
+    <operation
+      id="tag"
+      description="Preparing silence detection for preview">
+      <configurations>
+        <configuration key="source-flavors">*/silence</configuration>
+        <configuration key="target-tags">+archive</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Publish previews                                                  -->
+    <!--                                                                   -->
+    <!-- Distributing preview artifacts to preview publication channel.    -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Publish previews -->
+
+    <operation
+      id="publish-configure"
+      exception-handler-workflow="partial-error"
+      description="Publish to preview publication channel">
+      <configurations>
+        <configuration key="source-tags">preview</configuration>
+        <configuration key="channel-id">internal</configuration>
+        <configuration key="url-pattern">http://localhost:8080/admin-ng/index.html#/events/events/${event_id}/tools/playback</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>

--- a/post-archive/bbb-partial-publish.xml
+++ b/post-archive/bbb-partial-publish.xml
@@ -1,0 +1,521 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>bbb-partial-publish</id>
+  <title>Publish the recording(bigbluebutton)</title>
+  <tags/>
+  <description/>
+
+  <configuration_panel/>
+
+  <operations>
+
+    <operation
+        id="select-tracks"
+        exception-handler-workflow="partial-error"
+        description="Preparing presenter (camera) audio and video work versions">
+      <configurations>
+        <configuration key="source-flavor">*/prepared</configuration>
+        <configuration key="target-flavor">*/work</configuration>
+        <configuration key="target-tags">-archive</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        id="analyze-tracks"
+        exception-handler-workflow="partial-error"
+        description="Analyze tracks in media package a set control variables">
+      <configurations>
+        <configuration key="source-flavor">*/work</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Cut the video according the SMIL file                             -->
+    <!--                                                                   -->
+    <!-- Perform cutting according to the edit decision list.              -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <operation
+        id="clone"
+        exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavor">smil/cutting</configuration>
+        <configuration key="target-flavor">smil/tmp</configuration>
+      </configurations>
+    </operation>
+
+    <operation id="editor"
+      exception-handler-workflow="partial-error"
+      description="Cut the recording according to the edit decision list">
+      <configurations>
+        <configuration key="source-flavors">*/work</configuration>
+        <configuration key="smil-flavors">smil/tmp</configuration>
+        <configuration key="target-smil-flavor">smil/tmp</configuration>
+        <configuration key="target-flavor-subtype">trimmed</configuration>
+        <configuration key="interactive">false</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag any optionally uploaded assets -->
+    <operation
+      id="tag"
+      if="${downloadSourceflavorsExist}"
+      exception-handler-workflow="partial-error"
+      description="Tagging uploaded assets for distribution">
+      <configurations>
+        <configuration key="source-flavors">${download-source-flavors}</configuration>
+        <configuration key="target-tags">+engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Extract preview images                                            -->
+    <!--                                                                   -->
+    <!-- From the edited recording, take preview images for the player,    -->
+    <!-- search results etc.                                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Encode to engage search result thumbnails -->
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==0 AND ${presenter_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Creating search result default thumbnails">
+      <configurations>
+        <configuration key="source-flavor">presenter/work</configuration>
+        <configuration key="target-flavor">presenter/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==0 AND (${presentation_work_video} AND NOT (${presenter_work_video}))"
+      exception-handler-workflow="partial-error"
+      description="Creating search result default thumbnails">
+      <configurations>
+        <configuration key="source-flavor">presentation/work</configuration>
+        <configuration key="target-flavor">presentation/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==2"
+      exception-handler-workflow="partial-error"
+      description="Creating search result thumbnail from saved position">
+      <configurations>
+        <configuration key="source-flavor">${thumbnailTrack}/work</configuration>
+        <configuration key="target-flavor">*/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image-convert"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presenter_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Convert uploaded thumbnail to search result thumbnail (presenter track)">
+      <configurations>
+        <configuration key="source-flavors">thumbnail/source</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="target-flavor">presenter/search+preview</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image-convert"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presentation_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Convert uploaded thumbnail to search result thumbnail (presentation track)">
+      <configurations>
+        <configuration key="source-flavors">thumbnail/source</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="target-flavor">presentation/search+preview</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Encode to engage player preview images -->
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating player preview image">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">*/player+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">player-preview.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Encode to feed cover images -->
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating feed cover image">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">*/feed+preview</configuration>
+        <configuration key="target-tags">atom,rss</configuration>
+        <configuration key="encoding-profile">feed-cover.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+
+    <!-- Create a cover image with the default template -->
+
+    <operation
+      id="tag"
+      description="Removing unneeded presenter-cover from download publication">
+      <configurations>
+        <configuration key="source-flavors">presenter/player+preview</configuration>
+        <configuration key="target-tags">-engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating player preview image">
+      <configurations>
+        <configuration key="source-flavor">presenter/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">presenter/coverbackground</configuration>
+        <configuration key="encoding-profile">player-preview.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="cover-image"
+      fail-on-error="false"
+      exception-handler-workflow="partial-error"
+      description="Create a cover image">
+      <configurations>
+        <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
+        <configuration key="width">1920</configuration>
+        <configuration key="height">1080</configuration>
+        <configuration key="posterimage-flavor">presenter/coverbackground</configuration>
+        <configuration key="target-flavor">presenter/player+preview</configuration>
+        <configuration key="target-tags">archive, engage-download</configuration>
+     </configurations>
+    </operation>
+
+    <!-- Generate timeline preview images -->
+
+    <operation
+      id="timelinepreviews"
+      fail-on-error="false"
+      exception-handler-workflow="partial-error"
+      description="Creating timeline preview images">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="target-flavor">*/timeline+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="image-count">100</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Apply the branding artifacts                                      -->
+    <!--                                                                   -->
+    <!-- Add trailer and bumper to the recording prior to publication.     -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Apply the theme to the mediapackage -->
+
+    <operation
+      id="theme"
+      exception-handler-workflow="partial-error"
+      description="Apply the theme">
+      <configurations>
+        <configuration key="bumper-flavor">branding/bumper</configuration>
+        <configuration key="bumper-tags">archive</configuration>
+        <configuration key="trailer-flavor">branding/trailer</configuration>
+        <configuration key="trailer-tags">archive</configuration>
+        <configuration key="title-slide-flavor">branding/titleslide</configuration>
+        <configuration key="title-slide-tags">archive</configuration>
+        <configuration key="watermark-flavor">branding/watermark</configuration>
+        <configuration key="watermark-tags">archive</configuration>
+        <configuration key="watermark-layout">theme_watermark_layout</configuration>
+        <configuration key="watermark-layout-variable">theme_watermark_layout_variable</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Inspect the media from the theme -->
+
+    <operation
+      id="inspect"
+      exception-handler-workflow="partial-error"
+      description="Inspecting audio and video streams">
+      <configurations>
+        <configuration key="overwrite">false</configuration>
+        <configuration key="accept-no-media">false</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Create a title slide video if theme has active title slide -->
+    <operation
+      id="include"
+      description="Prepare title slide video"
+      if="${theme_title_slide_active}">
+      <configurations>
+        <configuration key="workflow-id">partial-title-slide</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Render watermarks into video tracks -->
+    <operation
+      id="include"
+      description="Render watermarks into video tracks"
+      if="${theme_watermark_active}">
+      <configurations>
+        <configuration key="workflow-id">partial-watermark</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag the dublin core catalogs created during trim operation for archival and publication -->
+
+    <operation
+      id="tag"
+      description="Tagging presenter track as input for next operation"
+      if="NOT (${theme_watermark_active})">
+      <configurations>
+        <configuration key="source-flavors">presenter/trimmed</configuration>
+        <configuration key="target-flavor">presenter/branded</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="tag"
+      description="Tagging presentation track as input for next operation"
+      if="NOT (${theme_watermark_active})">
+      <configurations>
+        <configuration key="source-flavors">presentation/trimmed</configuration>
+        <configuration key="target-flavor">presentation/branded</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Add bumper and trailer part to the presenter track -->
+
+    <operation
+      id="concat"
+      exception-handler-workflow="partial-error"
+      description="Concatenate presenter track with intro, title slide and outro videos">
+      <configurations>
+        <configuration key="source-flavor-part-0">branding/bumper</configuration>
+        <configuration key="source-flavor-part-0-mandatory">${theme_bumper_active}</configuration>
+        <configuration key="source-flavor-part-1">branding/titleslide+video</configuration>
+        <configuration key="source-flavor-part-1-mandatory">${theme_title_slide_active}</configuration>
+        <configuration key="source-flavor-part-2">presenter/branded</configuration>
+        <configuration key="source-flavor-part-2-mandatory">true</configuration>
+        <configuration key="source-flavor-part-3">branding/trailer</configuration>
+        <configuration key="source-flavor-part-3-mandatory">${theme_trailer_active}</configuration>
+        <configuration key="target-flavor">presenter/themed</configuration>
+        <configuration key="encoding-profile">concat.work</configuration>
+        <configuration key="output-resolution">part-2</configuration>
+        <configuration key="output-framerate">part-2</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Add bumper and trailer part to the presentation track -->
+
+    <operation
+      id="concat"
+      exception-handler-workflow="partial-error"
+      description="Concatenate presentation track with intro, title slide and outro videos">
+      <configurations>
+        <configuration key="source-flavor-part-0">branding/bumper</configuration>
+        <configuration key="source-flavor-part-0-mandatory">${theme_bumper_active}</configuration>
+        <configuration key="source-flavor-part-1">branding/titleslide+video</configuration>
+        <configuration key="source-flavor-part-1-mandatory">${theme_title_slide_active}</configuration>
+        <configuration key="source-flavor-part-2">presentation/branded</configuration>
+        <configuration key="source-flavor-part-2-mandatory">true</configuration>
+        <configuration key="source-flavor-part-3">branding/trailer</configuration>
+        <configuration key="source-flavor-part-3-mandatory">${theme_trailer_active}</configuration>
+        <configuration key="target-flavor">presentation/themed</configuration>
+        <configuration key="encoding-profile">concat.work</configuration>
+        <configuration key="output-resolution">part-2</configuration>
+        <configuration key="output-framerate">part-2</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Encode for publication to Engage                                  -->
+    <!--                                                                   -->
+    <!-- Encode audio and video formats to the distribution formats that   -->
+    <!-- are required by the Engage publication channel.                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Encode presenter (camera) to Engage player format -->
+    <operation
+        id="encode"
+        exception-handler-workflow="partial-error"
+        description="Encoding presentation videos to delivery formats">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming</configuration>
+        <configuration key="encoding-profile">studio.adaptive-parallel.http</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+        id="tag"
+        exception-handler-workflow="partial-error"
+        description="Tagging source material for download">
+      <configurations>
+        <configuration key="source-tags">720p-quality</configuration>
+        <configuration key="target-tags">+rss,+atom,+download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Segment video streams and extract metadata                        -->
+    <!--                                                                   -->
+    <!-- Apply the video segmentation algorithm to the presentation tracks -->
+    <!-- and extract segment preview images and metadata.                  -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Run the videosegmentation -->
+
+    <operation
+      id="segment-video"
+      fail-on-error="false"
+      description="Detecting slide transitions in presentation track">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Generate segment preview images -->
+
+    <operation
+      id="segmentpreviews"
+      fail-on-error="false"
+      description="Creating preview images for presentation segments">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-flavor">presentation/segment+preview</configuration>
+        <configuration key="reference-flavor">presentation/delivery</configuration>
+        <configuration key="reference-tags">engage-download</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">player-slides.http</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Extract text form slide preview images -->
+
+    <operation
+      id="extract-text"
+      fail-on-error="false"
+      description="Extracting text from presentation segments">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Publish to publication channels                                   -->
+    <!--                                                                   -->
+    <!-- Send the encoded material along with the metadata to the          -->
+    <!-- publication channels.                                             -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Publish to engage player -->
+
+    <operation
+      id="publish-engage"
+      if="${publishToEngage}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to Opencast Media Module">
+      <configurations>
+        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download,atom,rss,mobile</configuration>
+        <configuration key="streaming-source-tags">engage-streaming</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="publish-aws"
+      if="${publishToAws}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to Amazon Web Services">
+      <configurations>
+        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download,atom,rss,mobile</configuration>
+        <configuration key="streaming-source-tags">engage-streaming</configuration>
+        <configuration key="strategy">merge</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="publish-configure"
+      if="${publishToApi}"
+      exception-handler-workflow="partial-error"
+      description="Publish to external api publication channel">
+      <configurations>
+        <configuration key="channel-id">api</configuration>
+        <configuration key="mimetype">application/json</configuration>
+        <configuration key="source-tags">engage-download,engage-streaming</configuration>
+        <configuration key="url-pattern">http://localhost:8080/api/events/${event_id}</configuration>
+        <configuration key="with-published-elements">false</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Publish to OAI-PMH -->
+
+    <operation
+      id="publish-oaipmh"
+      if="${publishToOaiPmh}"
+      exception-handler-workflow="partial-error"
+      description="Publish to OAI-PMH Default Repository">
+      <configurations>
+        <configuration key="download-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-tags">engage-download,atom,rss</configuration>
+        <configuration key="streaming-tags">engage-streaming</configuration>
+        <configuration key="check-availability">true</configuration>
+        <configuration key="repository">default</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Publish to YouTube -->
+
+    <operation
+      id="publish-youtube"
+      if="${publishToYouTube}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to YouTube">
+      <configurations>
+        <configuration key="source-tags">youtube</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>

--- a/post-archive/bbb-upload-test.xml
+++ b/post-archive/bbb-upload-test.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <definition xmlns="http://workflow.opencastproject.org">
 
-  <id>bbb-upload</id>
-  <title>BigBlueButton Upload</title>
+  <id>bbb-upload-test</id>
+  <title>test BigBlueButton Upload</title>
   <tags>
     <tag>archive</tag>
+    <tag>upload</tag>
   </tags>
   <displayOrder>1000</displayOrder>
   <description>

--- a/post-archive/bbb-upload.xml
+++ b/post-archive/bbb-upload.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <definition xmlns="http://workflow.opencastproject.org">
 
-  <id>bbb-upload-test</id>
-  <title>test BigBlueButton Upload</title>
+  <id>bbb-upload</id>
+  <title>BigBlueButton Upload</title>
   <tags>
     <tag>archive</tag>
-    <tag>upload</tag>
   </tags>
   <displayOrder>1000</displayOrder>
   <description>

--- a/post-archive/bbb-upload.xml
+++ b/post-archive/bbb-upload.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <definition xmlns="http://workflow.opencastproject.org">
 
-  <id>bbb-upload</id>
-  <title>BigBlueButton Upload</title>
+  <id>bbb-upload-test</id>
+  <title>test BigBlueButton Upload</title>
   <tags>
     <tag>archive</tag>
+    <tag>upload</tag>
   </tags>
   <displayOrder>1000</displayOrder>
   <description>
@@ -218,3 +219,4 @@
   </operations>
 
 </definition>
+

--- a/post-archive/encoding/audio.properties
+++ b/post-archive/encoding/audio.properties
@@ -3,4 +3,4 @@ profile.audio-to-video.name = image-to-video
 profile.audio-to-video.input = stream
 profile.audio-to-video.output = audiovisual
 profile.audio-to-video.suffix = .mp4
-profile.audio-to-video.ffmpeg.command = -i #{in.video.path} -f lavfi -i color=c=black:s=640x480 -vf drawtext=fontsize=80:fontcolor=white:x=(w-text_w)/2:y=(h-text_h)/2.5:text=audio-only -c:v libx264 -tune stillimage -pix_fmt yuv420p -shortest -c:a aac -b:a 128k #{out.dir}/#{out.name}#{out.suffix}
+profile.audio-to-video.ffmpeg.command = -i #{in.video.path} -f lavfi -i color=c=black:s=640x480 -vf drawtext=fontsize=80:fontcolor=white:x=(w-text_w)/2:y=(h-text_h)/2.5:text=Nur-Audio -c:v libx264 -tune stillimage -pix_fmt yuv420p -shortest -c:a aac -b:a 128k #{out.dir}/#{out.name}#{out.suffix}

--- a/post-archive/encoding/audio.properties
+++ b/post-archive/encoding/audio.properties
@@ -1,0 +1,6 @@
+# Image to video
+profile.audio-to-video.name = image-to-video
+profile.audio-to-video.input = stream
+profile.audio-to-video.output = audiovisual
+profile.audio-to-video.suffix = .mp4
+profile.audio-to-video.ffmpeg.command = -i #{in.video.path} -f lavfi -i color=c=black:s=640x480 -vf drawtext=fontsize=80:fontcolor=white:x=(w-text_w)/2:y=(h-text_h)/2.5:text=audio-only -c:v libx264 -tune stillimage -pix_fmt yuv420p -shortest -c:a aac -b:a 128k #{out.dir}/#{out.name}#{out.suffix}


### PR DESCRIPTION
Some Parts of Opencast and the Paella Player can not handle Audio files.
This patch makes a blackscreen video out of an audio file.
So Opencast can handle "Podcasts"