### PR TITLE
Added a new metadata parameter for webcams

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make sure to read through the different options and evaluate which integration b
 - [Post-publish Integration](post-publish) – This integration leverages the recording processing capabilities of BigBlueButton to then transfer the processed video files to Opencast.
   The advantage is that this integration is relatively small and easy to use. The downside is that a lot of the processing happens on the BigBlueButton servers,
   taking away processing power from your next video conference.
-  
+
 - [Post-archive Integration](post-archive) – This integration sends the raw recording data from a BigBlueButton Meeting to Opencast and relies on Opencast itself to process it.
   This reduces the load on BigBlueBUtton servers which could otherwise decrease audio and video quality for further conferences. However, this solution is less feature complete, as Opencast still needs to be taught how to properly process webconferencing data.
 
@@ -117,3 +117,14 @@ An addition to the ACLs of the meeting, the series can have its own ACLs as well
     - Example: ROLE_USER,ROLE_XY
 - opencast-series-acl-write-roles
     - Example: ROLE_XY
+
+
+Parameters
+----------------
+
+Various parameters that change the behaviour of the integrations.
+- opencast-add-webcams
+  - Boolean on whether webcams should be sent to Opencast
+  - Important: The post-archive integration also has this a global configuration option. If that is set to false, the parameter will be ignored!
+  - Default for post-publish: true
+  - Default for post-archive: The global configuration option

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -598,9 +598,16 @@ end
 #
 
 # Add webcam tracks
-if ($config.dig(:addFiles, :webcamTracks))
-  tracks = collectFileInformation(tracks, 'presenter/source', webcamStart, real_start_time)
+if meeting_metadata["opencast-add-webcams"].nil?
+  if ($config.dig(:addFiles, :webcamTracks))
+    tracks = collectFileInformation(tracks, 'presenter/source', webcamStart, real_start_time)
+  end
+else
+  if ($config.dig(:addFiles, :webcamTracks) && meeting_metadata["opencast-add-webcams"] == 'true')
+    tracks = collectFileInformation(tracks, 'presenter/source', webcamStart, real_start_time)
+  end
 end
+
 # Add audio tracks (Likely to be only one track)
 tracks = collectFileInformation(tracks, 'presentation/source', audioStart, real_start_time)
 # Add screen share tracks

--- a/post-publish/post_publish.rb
+++ b/post-publish/post_publish.rb
@@ -82,6 +82,11 @@ ACL_PATH = File.join(published_files, "acl.xml")
 
 BigBlueButton.logger.info( "Prepare Metadata for [#{meeting_id}]...")
 
+# Check parameters sent via metadata
+if meeting_metadata["opencast-add-webcams"].nil?
+  meeting_metadata["opencast-add-webcams"] = 'true'
+end
+
 # Create metadata file dublincore
 dc_data = OcDublincore::parseDcMetadata(meeting_metadata, server: oc_server, user: oc_user, password: oc_password)
 dublincoreXML = OcDublincore::createDublincore(dc_data)
@@ -120,7 +125,7 @@ doc = Nokogiri::XML(mediapackage)
 mediapackageId = doc.xpath("/*")[0].attr('id')
 
 # Add Track
-if (File.exists?(published_files + '/video/webcams.webm'))
+if (File.exists?(published_files + '/video/webcams.webm') && meeting_metadata["opencast-add-webcams"] == 'true')
   BigBlueButton.logger.info( "Found presenter video")
   mediapackage = OcUtil::requestIngestAPI(oc_server, oc_user, oc_password,
                   :post, '/ingest/addPartialTrack', DEFAULT_REQUEST_TIMEOUT,


### PR DESCRIPTION
Adds a new parameter 'opencast-add-webcams' that can be passed to the script just like metadata. It enables/disables sending webcams to Opencast (depending on the integration). If the parameter is not specified, intergrations will behave as they did previously.