### PR TITLE
Fix equals for add-webcams parameter

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -603,7 +603,7 @@ if meeting_metadata["opencast-add-webcams"].nil?
     tracks = collectFileInformation(tracks, 'presenter/source', webcamStart, real_start_time)
   end
 else
-  if ($config.dig(:addFiles, :webcamTracks) && meeting_metadata["opencast-add-webcams"] == 'true')
+  if ($config.dig(:addFiles, :webcamTracks) && meeting_metadata["opencast-add-webcams"].to_s == 'true')
     tracks = collectFileInformation(tracks, 'presenter/source', webcamStart, real_start_time)
   end
 end


### PR DESCRIPTION
The equals check does not work properly, as `meeting_metadata["opencast-add-webcams"]` is a Nokogiri Node, not it's value.