### PR TITLE
Allow skip processing if no series ID is set

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -32,7 +32,7 @@ config_defaults = {
   },
   miscellaneous: {
     createNewSeriesIfItDoesNotYetExist: false,
-    skipProcessingIfNoSeriesIdSet: true,
+    skipProcessingIfNoSeriesIdSet: false,
     passIdentifierAsDcSource: false,
     onlyIngestIfRecordButtonWasPressed: false,
     doNotConvertVideosAgain: false,
@@ -221,7 +221,7 @@ end
 #
 # Checks if the video requires transcoding before sending it to Opencast
 # * Checks if a video has a width and height that is divisible by 2
-#   If not, crops the video to have one 
+#   If not, crops the video to have one
 # * Checks if the video is missing duration metadata
 #   If it's missing, copies the video to add it
 #

--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -32,6 +32,7 @@ config_defaults = {
   },
   miscellaneous: {
     createNewSeriesIfItDoesNotYetExist: false,
+    skipProcessingIfNoSeriesIdSet: true,
     passIdentifierAsDcSource: false,
     onlyIngestIfRecordButtonWasPressed: false,
     doNotConvertVideosAgain: false,
@@ -503,6 +504,15 @@ archived_files = "/var/bigbluebutton/recording/raw/#{meeting_id}"
 meeting_metadata = BigBlueButton::Events.get_meeting_metadata("#{archived_files}/events.xml")
 xml_path = archived_files +"/events.xml"
 BigBlueButton.logger.info("Series id: #{meeting_metadata["opencast-series-id"]}")
+
+if ($config.dig(:miscellaneous, :skipProcessingIfNoSeriesIdSet))
+  seriesId = meeting_metadata["opencast-dc-ispartof"]
+  if (seriesId.to_s.empty?)
+    BigBlueButton.logger.info("Series ID not found. Processing will continue with BBB defaults.")
+    # Just exit, do NOT clean up!
+    exit 0
+  end
+end
 
 # Variables
 mediapackage = ''

--- a/post-archive/post_archive_config.toml
+++ b/post-archive/post_archive_config.toml
@@ -79,7 +79,7 @@ createNewSeriesIfItDoesNotYetExist = false
 
 # Whether to skip processing if no series ID was submitted as meeting metadata
 # Default: true
-skipProcessingIfNoSeriesIdSet = true
+skipProcessingIfNoSeriesIdSet = false
 
 # The given dublincore identifier will also passed to the dublincore source tag,
 # even if the given identifier cannot be used as the actual identifier for the vent

--- a/post-archive/post_archive_config.toml
+++ b/post-archive/post_archive_config.toml
@@ -77,6 +77,10 @@ seriesWritePerm = ""
 # Default: false
 createNewSeriesIfItDoesNotYetExist = false
 
+# Whether to skip processing if no series ID was submitted as meeting metadata
+# Default: true
+skipProcessingIfNoSeriesIdSet = true
+
 # The given dublincore identifier will also passed to the dublincore source tag,
 # even if the given identifier cannot be used as the actual identifier for the vent
 # Default: false


### PR DESCRIPTION
Hi @Arnei 
for better load balancing we use just one BBB instance (with scalelite) with Stud.IP, ILIAS and Greenlight as a frontend.

We'd like to process recordings from Stud.IP with Opencast and others with BBB. In order for this to work, we need to skip processing with the BBB integration if no series ID is set.