### PR TITLE
Allow to specify minimal recording duration

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -571,6 +571,12 @@ end
 
 # Get conference start and end timestamps in ms
 real_start_time, real_end_time = getRealStartEndTimes(doc)
+# Exit program if the recording was too short
+if (real_end_time - real_start_time) < ($config.dig(:miscellaneous, :minimalDuration) * 1000)
+  BigBlueButton.logger.info( "Recording too short, aborting...")
+  cleanup(TMP_PATH, meeting_id)
+  exit 0
+end
 # Get screen share start timestamps
 deskshareStart = parseTimeStamps(doc, 'StartWebRTCDesktopShareEvent', deskshareStart, DESKSHARE_PATH)
 # Get webcam share start timestamps

--- a/post-archive/post_archive_config.toml
+++ b/post-archive/post_archive_config.toml
@@ -105,7 +105,7 @@ doNotConvertVideosAgain = false
 # Minimal accepted duration of recordings in seconds
 # This value can be used to discard recordings that are shorter than this value.
 # This can be helpful when dealing with a lot of short videos due to people peeking into
-# conferences before they start and that have set 'autoStartRecodring' to 'true'.
+# conferences before they start and that have set 'autoStartRecording' to 'true'.
 minimalDuration = 0
 
 # Monitor Opencast workflow state after ingest to determine whether the workflow was successful.

--- a/post-archive/post_archive_config.toml
+++ b/post-archive/post_archive_config.toml
@@ -102,6 +102,11 @@ onlyIngestIfRecordButtonWasPressed = false
 # Default: false
 doNotConvertVideosAgain = false
 
+# Minimal accepted duration of recordings in seconds
+# This value can be used to discard recordings that are shorter than this value.
+# This can be helpful when dealing with a lot of short videos due to people peeking into
+# conferences before they start and that have set 'autoStartRecodring' to 'true'.
+minimalDuration = 0
 
 # Monitor Opencast workflow state after ingest to determine whether the workflow was successful.
 # EXPERIMENTIAL! This may cause the process spawned from this script to run a lot longer than anticipated.


### PR DESCRIPTION
This commit introduces a new config parameter 'minimalDuration'.
This allows to define a minimal duration that recordings need to have
in order to be processed and send to Opencast.

The default is set to `0` which means that all recordings are normally processed.

Closes #49