### PR TITLE
Handling videos with size zero, fixes #55

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -238,6 +238,11 @@ def checkForTranscode(path, filename)
   pathToFile = File.join(path, filename)
   outputPathToFile = File.join(TMP_PATH, pathToFile)
 
+  if (File.zero?(pathToFile))
+    BigBlueButton.logger.info( "Video file #{pathToFile} has size zero, skipping...")
+    return path
+  end
+
   if ($config.dig(:miscellaneous, :doNotConvertVideosAgain) && File.exists?(outputPathToFile))
     BigBlueButton.logger.info( "Converted video for #{pathToFile} already exists, skipping...")
     return outputPathToFile


### PR DESCRIPTION
This pull requests presents a solution for the 'videos with size 0' problem by ignoring them.

Someone should check of `path` is a reasonable return value in that case.