### PR TITLE
Add support for new recording format "video"

### DIFF
--- a/post-publish/README.md
+++ b/post-publish/README.md
@@ -12,12 +12,13 @@ The Idea
     - Combined video of all webcams
     - Video of Screen recording
     - Combined audio
+    - Single file recording (see [Configure Single File Recording](#configure-single-file-recording))
 
 Requirements
 ------------
 
 - The Ruby gem `rest-client` is used to send requests to Opencast.
-If it is not yet installed, manually install it via `gem install rest-client`.
+If it is not yet installed, add the line `gem 'rest-client'` to the `GEMFILE` located at `/usr/local/bigbluebutton/core/Gemfile`. Possibly, you also need to add `gem 'toml-rb'` and `gem 'shellwords'` to the `GEMFILE`.
 
 Set Up BigBlueButton
 ----------------------
@@ -34,6 +35,39 @@ modules that are necessary for the script to run.
 
     /usr/local/bigbluebutton/core/scripts/post_publish/oc_modules
 
+Configure Single File Recording
+-------------------------------
+
+The single file recording contains webcams, presentation and screensharing. This recording provides an alternative to the separate video files that are uploaded to Opencast. To process and transfer these recordings, you need to enable the `video` format on your BigBlueButton server.
+
+1. Install the package:
+
+        apt-get install bbb-playback-video
+
+2. Edit `/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml`:
+
+        steps:
+            archive: "sanity"
+            sanity: "captions"
+            captions:
+                - "process:presentation"
+                - "process:video"
+            "process:presentation": "publish:presentation"
+            "process:video": "publish:video"
+
+    Alternative, if you don't want to process and upload the separate video files:
+
+        steps:
+            archive: "sanity"
+            sanity: "captions"
+            captions: "process:video"
+            "process:video": "publish:video"
+
+3. Restart processes:
+
+        systemctl restart bbb-rap-resque-worker.service nginx
+
+For more details, see [Install additional recording processing formats](https://docs.bigbluebutton.org/2.6/administration/customize#install-additional-recording-processing-formats).
 
 Limitations
 -----------

--- a/post-publish/README.md
+++ b/post-publish/README.md
@@ -77,3 +77,8 @@ Nevertheless, there are a few limitations.
 
 - BigBlueButton includes audio only in the camera recording, not in the screen recording.
   Your Opencast workflow will need to fix that.
+  
+Known Issue
+-----------
+
+Possibly, the media files for the format `presentation` could be missing in the transmitted media package and could lead to processing errors in your opencast workflow. This could be caused by disabled processing scripts for `presentation` by the command `sudo bbb-record --disable presentation` on your bbb instance. The scripts can be enabled with `sudo bbb-record --enable presentation` and everything should work fine.

--- a/post-publish/README.md
+++ b/post-publish/README.md
@@ -12,13 +12,13 @@ The Idea
     - Combined video of all webcams
     - Video of Screen recording
     - Combined audio
-    - Single file recording (see [Configure Single File Recording](#configure-single-file-recording))
+- Based on BigBlueButton configuration a single file recording can be transfered (see [Configure Single File Recording](#configure-single-file-recording))
 
 Requirements
 ------------
 
 - The Ruby gem `rest-client` is used to send requests to Opencast.
-If it is not yet installed, add the line `gem 'rest-client'` to the `GEMFILE` located at `/usr/local/bigbluebutton/core/Gemfile`. Possibly, you also need to add `gem 'toml-rb'` and `gem 'shellwords'` to the `GEMFILE`.
+If it is not yet installed, add the line `gem 'rest-client'` to the `GEMFILE` located at `/usr/local/bigbluebutton/core/Gemfile`. If not already present in the gemfile, you also need to add `gem 'toml-rb'` and `gem 'shellwords'`. Finally, you need to run `bundle install` to install the gems.
 
 Set Up BigBlueButton
 ----------------------
@@ -38,7 +38,7 @@ modules that are necessary for the script to run.
 Configure Single File Recording
 -------------------------------
 
-The single file recording contains webcams, presentation and screensharing. This recording provides an alternative to the separate video files that are uploaded to Opencast. To process and transfer these recordings, you need to enable the `video` format on your BigBlueButton server.
+The single file recording contains webcams, presentation including markings, screensharing, poll results and audio. This file does not include chat, notes, users list and shared external videos. This recording provides an alternative to the separate video files that are uploaded to Opencast. To process and transfer these recordings, you need to enable the `video` format on your BigBlueButton server.
 
 1. Install the package:
 
@@ -55,7 +55,7 @@ The single file recording contains webcams, presentation and screensharing. This
             "process:presentation": "publish:presentation"
             "process:video": "publish:video"
 
-    Alternative, if you don't want to process and upload the separate video files:
+    Alternatively, if you want to process and transfer only the single recording file, remove in `steps` the lines of the "presentation" format as follows:
 
         steps:
             archive: "sanity"
@@ -67,7 +67,7 @@ The single file recording contains webcams, presentation and screensharing. This
 
         systemctl restart bbb-rap-resque-worker.service nginx
 
-For more details, see [Install additional recording processing formats](https://docs.bigbluebutton.org/2.6/administration/customize#install-additional-recording-processing-formats).
+For more details, see [Install additional recording processing formats](https://docs.bigbluebutton.org/administration/customize/#install-additional-recording-processing-formats).
 
 Limitations
 -----------

--- a/post-publish/post_publish_config.toml
+++ b/post-publish/post_publish_config.toml
@@ -5,7 +5,7 @@
 [opencast]
 # Server URL
 # Example: server = 'https://develop.opencast.org'
-server = 'https://develop.opencast.org'
+server = 'http://localhost:8080'
 
 # User credentials allowed to ingest via HTTP basic
 # Example: user = 'username'
@@ -15,7 +15,7 @@ password = 'opencast'
 
 # Workflow to use for ingest
 # Example: workflow = 'bbb-upload'
-workflow = 'fast'
+workflow = 'schedule-and-upload'
 
 
 # Allows you to add default Opencast roles to every recording

--- a/post-publish/post_publish_config.toml
+++ b/post-publish/post_publish_config.toml
@@ -5,7 +5,7 @@
 [opencast]
 # Server URL
 # Example: server = 'https://develop.opencast.org'
-server = 'http://localhost:8080'
+server = 'https://develop.opencast.org'
 
 # User credentials allowed to ingest via HTTP basic
 # Example: user = 'username'
@@ -15,7 +15,7 @@ password = 'opencast'
 
 # Workflow to use for ingest
 # Example: workflow = 'bbb-upload'
-workflow = 'schedule-and-upload'
+workflow = 'fast'
 
 
 # Allows you to add default Opencast roles to every recording


### PR DESCRIPTION
Adds support for the new bbb recording format "video". This format creates a single video file `video-0.m4v` from the webcam videos and the presentation video. If the old format `presentation` and the new format are enabled as described below, the `post_publish` script will be executed for each format, in this case twice. Then both formats will be ingested into opencast.

### Steps to enable the new, single-file recording format "video" in BigBlueButton 2.6

1. Add packages
    ```bash
    apt-get install bbb-playback-video
    ```
2. Edit `/usr/local/bigbluebutton/core/scripts/bigbluebutton.yml`
    ```yaml=
    steps:
      archive: "sanity"
      sanity: "captions"
      captions:
        - "process:presentation"
        - "process:video"
      "process:presentation": "publish:presentation"
      "process:video": "publish:video"
    ```
3. Restart processes
    ```bash
    systemctl restart bbb-rap-resque-worker.service nginx
    ```

The latest documentation can be found at:

- https://docs.bigbluebutton.org/2.6/administration/customize#install-additional-recording-processing-formats

### Known Issue
Possibly, the media files for the format `presentation` could be missing in the transmitted media package and could lead to processing errors in the defined opencast workflow. This is caused by disabled processing scripts for `presentation` by the command `sudo bbb-record --disable presentation` on your bbb instance. The scripts can be enabled with `sudo bbb-record --enable presentation` and everything should work fine.
