### PR TITLE
Log All Ingest Errors

### DIFF
--- a/oc_modules/oc_util.rb
+++ b/oc_modules/oc_util.rb
@@ -108,6 +108,10 @@ module OcUtil
       BigBlueButton.logger.info( e.http_body)
       BigBlueButton.logger.info( additionalErrorMessage)
       exit 1
+    rescue => e
+      BigBlueButton.logger.error("An unknown problem occured for request: #{url}")
+      BigBlueButton.logger.info(e)
+      exit 1
     end
 
     return response


### PR DESCRIPTION
Due to a misconfiguration, the script was failing to open a TCP connection to Opencast which caused an exception and caused the script to fail.

Unfortunately, this error was silenced and not logged at all, making it extremely hard to find out what was going on.

This patch makes sure that all errors are logged.