### PR TITLE
Update Series endpoints

### DIFF
--- a/oc_modules/oc_acl.rb
+++ b/oc_modules/oc_acl.rb
@@ -261,7 +261,7 @@ module OcAcl
       begin
         response = RestClient::Request.new(
           :method => :post,
-          :url => oc_server + '/api/series/',
+          :url => oc_server + '/series/',
           :user => oc_user,
           :password => oc_password,
           :payload => { :series => seriesDublincore,
@@ -281,7 +281,7 @@ module OcAcl
       begin
         seriesAcl = RestClient::Request.new(
           :method => :get,
-          :url => oc_server + '/api/series/' + createSeriesId + '/acl.xml',
+          :url => oc_server + '/series/' + createSeriesId + '/acl.xml',
           :user => oc_user,
           :password => oc_password,
           :payload => { }
@@ -297,7 +297,7 @@ module OcAcl
         begin
           response = RestClient::Request.new(
             :method => :post,
-            :url => oc_server + '/api/series/' + createSeriesId + '/accesscontrol',
+            :url => oc_server + '/series/' + createSeriesId + '/accesscontrol',
             :user => oc_user,
             :password => oc_password,
             :payload => { :acl => updatedSeriesAcl,


### PR DESCRIPTION
Opencast updated their series endpoint paths (in 12 and 13, yikes), which silently broke creating or updating series. This should fix that by updating the paths.