### PR TITLE
Simplify series exists check

### DIFF
--- a/oc_modules/oc_acl.rb
+++ b/oc_modules/oc_acl.rb
@@ -224,7 +224,11 @@ module OcAcl
         :url => oc_server + '/api/series/series.json',
         :user => oc_user,
         :password => oc_password,
-        :payload => {}
+        :headers => {
+          :params => {
+            :seriesId => createSeriesId,
+          },
+        }
       ).execute
     rescue RestClient::Exception => e
       "LOG WARN Could not acquire information about series, Exception #{e}"
@@ -235,16 +239,12 @@ module OcAcl
     seriesExists = false
     begin
       seriesFromOc = JSON.parse(seriesFromOc)
-      seriesFromOc.each do |serie|
-        BigBlueButton.logger.info( "OC_ACL: Found series: " + serie["identifier"].to_s)
-        if (serie["identifier"].to_s === createSeriesId.to_s)
-          seriesExists = true
-          BigBlueButton.logger.info( "OC_ACL: Series already exists")
-          break
-        end
+      if (seriesFromOc.length() > 0)
+        seriesExists = true
+        BigBlueButton.logger.info( "OC_ACL: Series already exists")
       end
     rescue JSON::ParserError  => e
-      BigBlueButton.logger.warn(" OC_ACL: Could not parse series JSON, Exception #{e}")
+      BigBlueButton.logger.warn("OC_ACL: Could not parse series JSON, Exception #{e}")
     end
 
     # Create Series

--- a/oc_modules/oc_acl.rb
+++ b/oc_modules/oc_acl.rb
@@ -261,7 +261,7 @@ module OcAcl
       begin
         response = RestClient::Request.new(
           :method => :post,
-          :url => oc_server + '/api/series/',
+          :url => oc_server + '/series/',
           :user => oc_user,
           :password => oc_password,
           :payload => { :series => seriesDublincore,
@@ -281,7 +281,7 @@ module OcAcl
       begin
         seriesAcl = RestClient::Request.new(
           :method => :get,
-          :url => oc_server + '/api/series/' + createSeriesId + '/acl.xml',
+          :url => oc_server + '/series/' + createSeriesId + '/acl.xml',
           :user => oc_user,
           :password => oc_password,
           :payload => { }
@@ -297,7 +297,7 @@ module OcAcl
         begin
           response = RestClient::Request.new(
             :method => :post,
-            :url => oc_server + '/api/series/' + createSeriesId + '/accesscontrol',
+            :url => oc_server + '/series/' + createSeriesId + '/accesscontrol',
             :user => oc_user,
             :password => oc_password,
             :payload => { :acl => updatedSeriesAcl,


### PR DESCRIPTION
We were fetching all series just to check if one with our series id exists. This is not terribly performant, so we should simplify it.