### PR TITLE
Send real start and end times in post publish

### DIFF
--- a/oc_modules/oc_util.rb
+++ b/oc_modules/oc_util.rb
@@ -118,4 +118,28 @@ module OcUtil
   end
   module_function :requestIngestAPI
 
+  #
+  # Parse TimeStamps - Start and End Time
+  #
+  # doc: file handle
+  #
+  # return: start and end time of the conference in ms (Unix EPOC)
+  #
+  def getRealStartEndTimes(doc)
+    # Parse general time values | Stolen from bigbluebutton/record-and-playback/presentation/scripts/process/presentation.rb
+    # Times in ms
+    meeting_start = doc.xpath("//event")[0][:timestamp]
+    meeting_end = doc.xpath("//event").last()[:timestamp]
+
+    meeting_id = doc.at_xpath("//meeting")[:id]
+    real_start_time = meeting_id.split('-').last
+    real_end_time = (real_start_time.to_i + (meeting_end.to_i - meeting_start.to_i)).to_s
+
+    real_start_time = real_start_time.to_i
+    real_end_time = real_end_time.to_i
+
+    return real_start_time, real_end_time
+  end
+  module_function :getRealStartEndTimes
+
 end


### PR DESCRIPTION
The post_publish script has not been sending the start and end times of the recording to Opencast. It relied on that information being in the metadata tag in the events.xml, where it simply was not. This would result in Opencast displaying the ingest time as the start time instead of the start time of the recording.

This patch fixes that by employing the same mechanism the post_archive script already uses, which is looking at the timestamps of the first and last events in the events.xml, and then using those values.