### PR TITLE
Adopt new BBB PublicChatEvent

### DIFF
--- a/post-archive/post_archive.rb
+++ b/post-archive/post_archive.rb
@@ -361,6 +361,18 @@ def parseChat(doc, chatFilePath, realStartTime, recordingStart, recordingStop)
   displayMessageTimeMax = 3  # seconds
   chatMessages = []
 
+  # Build lookup table: userId -> display name
+  participants = {}
+
+  doc.xpath("//event[@eventname='ParticipantJoinEvent']").each do |node|
+    user_id = node.at_xpath("./userId")&.text
+    name    = node.at_xpath("./name")&.text
+
+    next unless user_id && name
+
+    participants[user_id] = name
+  end
+
   # Gather messages
   chatEvents = doc.xpath("//event[@eventname='PublicChatEvent']")
 
@@ -371,8 +383,19 @@ def parseChat(doc, chatFilePath, realStartTime, recordingStart, recordingStop)
       chatTimestamp = node.at_xpath("timestampUTC").content.to_i
 
       if (chatTimestamp >= recordStartStamp.to_i and chatTimestamp <= recordStopStamp.to_i)
-        chatSender = node.xpath(".//sender")[0].text()
-        chatMessage =  node.xpath(".//message")[0].text()
+        chatSender =
+          node.at_xpath("./sender")&.text ||
+          participants[node.at_xpath("./senderId")&.text] ||
+          ""
+
+        message_node = node.at_xpath("./message")
+        next unless message_node
+
+        chatMessage = Nokogiri::HTML::DocumentFragment
+          .parse(message_node.inner_html)
+          .text
+          .strip
+
         chatStart = Time.at((chatTimestamp - realStartTime) / 1000.0) #.utc.strftime(TIME_FORMAT)
         #chatEnd = Time.at((chatTimestamp - realStartTime) / 1000.0) + 2
         #chatEnd = chatEnd.utc.strftime(TIME_FORMAT)


### PR DESCRIPTION
Apparently, BBB changed their chat format at some point

A PublicChatEvent does not contain the user name ("sender") anymore.

```xml
<event timestamp="5775382" module="CHAT" eventname="PublicChatEvent">
    <chatEmphasizedText>true</chatEmphasizedText>
    <senderRole>MODERATOR</senderRole>
    <date>2026-06-30T16:03:03.654+02</date>
    <messageId>1782828183653-ca07436r</messageId>
    <message><p>test2 after recording start</p>
</message>
    <timestampUTC>1782828183654</timestampUTC>
    <replyToMessageId/>
    <senderId>user_id</senderId>
  </event>
```

Thus, we look-up the user's name at ParticipantJoinEvents:

```xml
 <event timestamp="186043" module="PARTICIPANT" eventname="ParticipantJoinEvent">
   <userdata>{}</userdata>
   <name>Mustermann, Max</name>
   <role>MODERATOR</role>
   <date>2026-06-30T14:29:54.315+02</date>
   <externalUserId>user_id</externalUserId>
   <userId>user_id</userId>
   <timestampUTC>1782822594315</timestampUTC>
 </event>
```

This fixes

> bbb-rap[2912]: /usr/local/bigbluebutton/core/scripts/post_archive/post_archive.rb:374:in `block (2 levels) in parseChat': undefined method `text' for nil:NilClass (NoMethodError)